### PR TITLE
 pcのイベントエディター画面でイベント詳細が表示されなくなっていたバグの修正

### DIFF
--- a/src/components/event/EventEditor.vue
+++ b/src/components/event/EventEditor.vue
@@ -144,7 +144,8 @@ onMounted(async () => {
       <div v-else style="display: flex; width: 100%; height: 100%">
         <EventEditorSettings
           :event="event"
-          style="width: 400px; height: 100%; padding: 20px"
+          class="h-100 pa-5"
+          style="width: 400px"
           v-model:name="name"
           v-model:location="location"
           v-model:startTime="startTime"
@@ -152,7 +153,7 @@ onMounted(async () => {
           v-model:color="color"
           @delete="deleteEvent"
         />
-        <div style="width: 100%; height: 100%; position: relative">
+        <div class="w-100 h-100">
           <MarkdownPlatform v-model:text="description" :color="color"></MarkdownPlatform>
         </div>
       </div>

--- a/src/components/event/EventEditor.vue
+++ b/src/components/event/EventEditor.vue
@@ -144,7 +144,7 @@ onMounted(async () => {
       <div v-else style="display: flex; width: 100%; height: 100%">
         <EventEditorSettings
           :event="event"
-          style="width: 400px; height: 100%; padding: 20px; flex-shrink: 0"
+          style="width: 400px; height: 100%; padding: 20px"
           v-model:name="name"
           v-model:location="location"
           v-model:startTime="startTime"

--- a/src/components/event/EventEditorSettings.vue
+++ b/src/components/event/EventEditorSettings.vue
@@ -87,7 +87,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="w-100 h-100">
+  <div class="h-100">
     <v-text-field
       v-model="name"
       :rules="[(v) => !!v || 'タイトルは必須です']"


### PR DESCRIPTION
pcの画面比率の際にコンポーネント内部の横幅の100%の設定優先されて表示が上手くいっていなかったバグを修正しました。