### PR TITLE
背景の右端に走っていた白い縦線を解消

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ const showLayout = computed(() => route.meta?.showLayout)
   <background-pattern
     :logo-color="showLayout ? '#FFFFFF' : '#FF8200'"
     :bg-color="showLayout ? '#F6F6F6' : '#FF7300'"
+    :is-global="true"
   />
   <v-app>
     <header-button v-if="showLayout" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,13 +7,17 @@ import BackgroundPattern from '@/components/generic/BackgroundPattern.vue'
 
 const route = useRoute()
 const showLayout = computed(() => route.meta?.showLayout)
+import { watchEffect } from 'vue'
+
+watchEffect(() => {
+  document.body.style.backgroundColor = showLayout.value ? '#F6F6F6' : '#FF7300'
+})
 </script>
 
 <template>
   <background-pattern
     :logo-color="showLayout ? '#FFFFFF' : '#FF8200'"
     :bg-color="showLayout ? '#F6F6F6' : '#FF7300'"
-    :is-global="true"
   />
   <v-app>
     <header-button v-if="showLayout" />

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -50,10 +50,6 @@
 body {
   min-height: 100vh;
   color: var(--color-text);
-  background: var(--color-background);
-  transition:
-    color 0.5s,
-    background-color 0.5s;
   line-height: 1.6;
   font-family: 'M PLUS 1p', sans-serif;
   font-size: 15px;

--- a/src/components/generic/BackgroundPattern.vue
+++ b/src/components/generic/BackgroundPattern.vue
@@ -1,19 +1,30 @@
 <script setup lang="ts">
-import { defineProps } from 'vue';
-defineProps<{
-  logoColor: string;
-  bgColor: string;
-}>();
+import { defineProps, watchEffect, withDefaults } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    logoColor: string
+    bgColor: string
+    isGlobal?: boolean
+  }>(),
+  {
+    isGlobal: false,
+  },
+)
+
+watchEffect(() => {
+  if (props.isGlobal) {
+    document.body.style.backgroundColor = props.bgColor
+  }
+})
 </script>
 
 <template>
-  <div :class="$style.background" :style="{backgroundColor: bgColor}">
+  <div :class="$style.background" :style="{ backgroundColor: props.bgColor }">
     <div :class="$style.center">
-      <div :class="$style.pattern" :style="{backgroundColor: logoColor}"></div>
+      <div :class="$style.pattern" :style="{ backgroundColor: props.logoColor }"></div>
     </div>
   </div>
-
-
 </template>
 
 <style module>
@@ -41,11 +52,13 @@ defineProps<{
   height: 8000px;
   width: 8000px;
   transform: rotate(-30deg);
-  mask-image:
-    url('/logo/logo-bg.svg'),
-    url('/logo/logo-bg.svg');
-  mask-size: 800px 600px, 800px 600px;
-  mask-position: 0 0, 400px 300px;
+  mask-image: url('/logo/logo-bg.svg'), url('/logo/logo-bg.svg');
+  mask-size:
+    800px 600px,
+    800px 600px;
+  mask-position:
+    0 0,
+    400px 300px;
   mask-repeat: repeat;
 }
 </style>

--- a/src/components/generic/BackgroundPattern.vue
+++ b/src/components/generic/BackgroundPattern.vue
@@ -1,22 +1,10 @@
 <script setup lang="ts">
-import { defineProps, watchEffect, withDefaults } from 'vue'
+import { defineProps } from 'vue'
 
-const props = withDefaults(
-  defineProps<{
-    logoColor: string
-    bgColor: string
-    isGlobal?: boolean
-  }>(),
-  {
-    isGlobal: false,
-  },
-)
-
-watchEffect(() => {
-  if (props.isGlobal) {
-    document.body.style.backgroundColor = props.bgColor
-  }
-})
+const props = defineProps<{
+  logoColor: string
+  bgColor: string
+}>()
 </script>
 
 <template>


### PR DESCRIPTION
BackgroundPattern.vue に与える bg-color がオレンジ色のとき、ブラウザで開くとウィンドウ右端に白の縦線が走っていて見栄えが悪かった
単なる黒背景を入れるなどして原因を辿ると base.css における body に対する背景色の設定が原因と分かった
- body に対する背景色の設定を BackgroundPattern.vue の中で動的に行い、トランジションも削除した
- BackgroundPattern.vue は App.vue のみならず PageNavigation.vue からも呼び出されているので、引数に isGlobal を加えて App.vue から呼び出された場合に限り body の bg-color の書き換えを行うようにした