### PR TITLE
Dockerの環境変数周りを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,6 @@ RUN npm ci
 # ソースコードをコピー
 COPY . .
 
-# ビルド引数として環境変数を受け取る
-ARG VITE_API_BASE_URL
-ARG VITE_DEV_USER
-ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
-ENV VITE_DEV_USER=$VITE_DEV_USER
-
 # アプリケーションをビルド
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# rucQ-UI
+
+- Server: [traPtitech/rucQ](https://github.com/traPtitech/rucQ)
+- Client: here
+
+## 環境構築
+
+- Node.js
+- Docker
+
+### リモートのStaging APIを使う方法 (Default)
+
+traQ 認証を突破するためにCookieをコピーしてくる必要があります。
+
+1. <https://rucq-dev.trap.show/api/me> にアクセスする
+2. Cookie一覧から `_forward_auth` の値を取得する
+3. `docker compose up --build -d` を実行する
+4. <http://localhost:5173> にアクセスし、DevtoolsでCookieをセットする
+  - Applicationタブ → Storage → Cookies → http://... にある
+5. ページをリロードするとAPIとの接続が確認できる
+
+### ローカルで建てたAPIを使う方法
+
+1. `.env` に以下を記述
+
+```bash
+VITE_API_BASE_URL="http://localhost:サーバーのポート"
+```
+
+2. `docker compose up --build -d` を実行する
+3. <http://localhost:5173> にアクセスする

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        - VITE_API_BASE_URL=${VITE_API_BASE_URL}
-        - VITE_DEV_USER=${VITE_DEV_USER}
+    environment:
+      VITE_DEV_USER: ${VITE_DEV_USER:-rucq}
     ports:
       - '5173:80'
     restart: unless-stopped

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* tslint:disable */
 
 /**

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,16 +1,14 @@
 import createClient from 'openapi-fetch'
 import type { paths } from '@/api/schema'
 
-const baseUrl = import.meta.env.VITE_API_BASE_URL
-const devUser = import.meta.env.VITE_DEV_USER
-
 // 開発環境用のヘッダー設定
 const headers: Record<string, string> = {}
-if (devUser) {
-  headers['X-Forwarded-User'] = devUser
+if (import.meta.env.DEV) {
+  headers['X-Forwarded-User'] = import.meta.env.VITE_DEV_USER
+    ? import.meta.env.VITE_DEV_USER
+    : 'rucq'
 }
 
 export const apiClient = createClient<paths>({
-  baseUrl: baseUrl,
   headers: headers,
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: process.env.VITE_API_BASE_URL,
+        target: process.env.VITE_API_BASE_URL
+          ? process.env.VITE_API_BASE_URL
+          : 'https://rucq-dev.trap.show',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
- 開発環境ではサーバーを/apiにプロキシするのでapiClient.tsで再度設定すると逆にCORSになる
- デフォルトでstaging serverにつなぐようにして初期の環境設定を簡単にする
- 開発環境の判定にはimport.meta.env.DEVを使う
