### PR TITLE
fix : height の変更

### DIFF
--- a/src/views/GuidebookView.vue
+++ b/src/views/GuidebookView.vue
@@ -70,7 +70,7 @@ const headings = ref<HeadingInfo[]>([])
 .sidebar {
   width: 280px;
   padding: 40px 16px;
-  max-height: calc(100vh - 80px);
+  height: 100%;
   overflow-y: auto;
   flex-shrink: 0;
   right: 0;


### PR DESCRIPTION
#66 
2重スクロールの解消から変更を忘れていたmax heightをhegiht :100%にしました
目次の下側に余白をあえて開けているようだったらプルリクエストは取り下げます