### PR TITLE
部屋情報ページの実装

### DIFF
--- a/src/mocks/handlers/rooms.ts
+++ b/src/mocks/handlers/rooms.ts
@@ -6,7 +6,7 @@ export const roomsHandlers = [
     return HttpResponse.json([
       {
         id: 1,
-        name: '東棟 2F',
+        name: '東棟 1F',
         rooms: [
           {
             id: 1,
@@ -27,7 +27,7 @@ export const roomsHandlers = [
       },
       {
         id: 2,
-        name: '東棟 3F',
+        name: '東棟 2F',
         rooms: [
           {
             id: 5,
@@ -40,6 +40,70 @@ export const roomsHandlers = [
             ],
           },
           { id: 6, name: '202', members: [{ id: 'kitsne', isStaff: true }] },
+        ],
+      },
+      {
+        id: 3,
+        name: '東棟 3F',
+        rooms: [
+          {
+            id: 7,
+            name: '301',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
+          { id: 8, name: '302', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 9, name: '303', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 10, name: '304', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 11, name: '305', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 12, name: '306', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 13, name: '307', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 14, name: '308', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 15, name: '309', members: [{ id: 'kitsne', isStaff: true }] },
+        ],
+      },
+      {
+        id: 4,
+        name: '東棟 4F',
+        rooms: [
+          {
+            id: 16,
+            name: '401',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
+          {
+            id: 17,
+            name: '402',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
+          {
+            id: 18,
+            name: '403',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
         ],
       },
     ])

--- a/src/mocks/handlers/rooms.ts
+++ b/src/mocks/handlers/rooms.ts
@@ -6,20 +6,40 @@ export const roomsHandlers = [
     return HttpResponse.json([
       {
         id: 1,
-        name: '1階',
+        name: '東棟 2F',
         rooms: [
-          { id: 1, name: '101', members: [{ id: 'traP', isStaff: true }] },
-          { id: 2, name: '102', members: [{ id: 'traP', isStaff: true }] },
-          { id: 3, name: '103', members: [{ id: 'traP', isStaff: true }] },
-          { id: 4, name: '104', members: [{ id: 'traP', isStaff: true }] },
+          {
+            id: 1,
+            name: '101',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
+          { id: 2, name: '102', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 3, name: '103', members: [{ id: 'kitsne', isStaff: true }] },
+          { id: 4, name: '104', members: [{ id: 'kitsne', isStaff: true }] },
         ],
       },
       {
         id: 2,
-        name: '2階',
+        name: '東棟 3F',
         rooms: [
-          { id: 5, name: '201', members: [{ id: 'traP', isStaff: true }] },
-          { id: 6, name: '202', members: [{ id: 'traP', isStaff: true }] },
+          {
+            id: 5,
+            name: '201',
+            members: [
+              { id: 'kitsne', isStaff: true },
+              { id: 'traP', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+              { id: 'kitsne', isStaff: true },
+            ],
+          },
+          { id: 6, name: '202', members: [{ id: 'kitsne', isStaff: true }] },
         ],
       },
     ])

--- a/src/mocks/handlers/rooms.ts
+++ b/src/mocks/handlers/rooms.ts
@@ -1,1 +1,27 @@
-export const roomsHandlers = []
+import { HttpResponse } from 'msw'
+import { http } from '@/mocks/http'
+
+export const roomsHandlers = [
+  http.get('/api/camps/{campId}/room-groups', async () => {
+    return HttpResponse.json([
+      {
+        id: 1,
+        name: '1階',
+        rooms: [
+          { id: 1, name: '101', members: [{ id: 'traP', isStaff: true }] },
+          { id: 2, name: '102', members: [{ id: 'traP', isStaff: true }] },
+          { id: 3, name: '103', members: [{ id: 'traP', isStaff: true }] },
+          { id: 4, name: '104', members: [{ id: 'traP', isStaff: true }] },
+        ],
+      },
+      {
+        id: 2,
+        name: '2階',
+        rooms: [
+          { id: 5, name: '201', members: [{ id: 'traP', isStaff: true }] },
+          { id: 6, name: '202', members: [{ id: 'traP', isStaff: true }] },
+        ],
+      },
+    ])
+  }),
+]

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,7 +31,7 @@ const router = createRouter({
         {
           path: 'rooms',
           name: '部屋情報',
-          component: () => import('@/views/WorkInProgressView.vue'),
+          component: () => import('@/views/RoomInfoView.vue'),
         },
       ],
     },

--- a/src/views/RoomInfoView.vue
+++ b/src/views/RoomInfoView.vue
@@ -93,7 +93,7 @@ onMounted(async () => {
   position: relative;
   max-width: 600px;
   margin: 0 auto;
-  padding: 32px 0;
+  padding: 32px 8px;
 }
 
 .card {

--- a/src/views/RoomInfoView.vue
+++ b/src/views/RoomInfoView.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { apiClient } from '@/api/apiClient'
+import type { components } from '@/api/schema'
+import UserIcon from '@/components/generic/UserIcon.vue'
+import { useCampStore } from '@/store'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const campStore = useCampStore()
+
+const displayCamp = computed(() => {
+  return campStore.getCampByDisplayId(route.params.campname as string)
+})
+
+type RoomGroup = components['schemas']['RoomGroupResponse']
+
+const roomGroups = ref<RoomGroup[]>([])
+
+const getRoomGroups = async () => {
+  const { data, error } = await apiClient.GET('/api/camps/{campId}/room-groups', {
+    params: { path: { campId: displayCamp.value.id } },
+  })
+  if (error || !data) throw error ?? new Error('Failed to fetch room groups')
+  return data
+}
+
+onMounted(async () => {
+  roomGroups.value = await getRoomGroups()
+})
+</script>
+
+<template>
+  <div :class="$style.container">
+    <div v-for="group in roomGroups" :key="group.id">
+      <div :class="$style.floorName">{{ group.name }}</div>
+      <div :class="$style.roomGrid">
+        <div v-for="room in group.rooms" :key="room.id">
+          <v-card elevation="0" color="primaryLight" class="ma-2 pa-2">
+            <v-card-title class="text-center pa-0">
+              <span :class="$style.roomName">
+                {{ room.name }}
+              </span>
+            </v-card-title>
+            <div class="w-100 d-flex flex-wrap justify-center">
+              <user-icon
+                v-for="user in room.members"
+                :id="user.id"
+                :key="user.id"
+                :size="30"
+                class="ma-1"
+              />
+            </div>
+          </v-card>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style module>
+.container {
+  position: relative;
+  max-width: 800px;
+  margin: 16px auto;
+}
+
+.floorName {
+  width: 200px;
+  font-weight: bold;
+  font-size: 20px;
+  border-bottom: 1px solid black;
+  margin-left: 16px;
+}
+
+.roomName {
+  font-weight: 900;
+  font-size: 20px;
+  color: rgb(var(--v-theme-primary));
+}
+
+.link {
+  display: block;
+  width: 100%;
+  text-align: center;
+  color: rgb(var(--v-theme-primary));
+  margin-bottom: 4;
+}
+
+.roomGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 8px;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.roomName {
+  font-weight: 900;
+  font-size: 24px;
+  letter-spacing: 0.5em;
+  color: rgb(var(--v-theme-primary));
+}
+</style>

--- a/src/views/RoomInfoView.vue
+++ b/src/views/RoomInfoView.vue
@@ -36,60 +36,74 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div :class="$style.container">
-    <div v-for="group in roomGroups" :key="group.id" class="d-flex flex-column align-center">
-      <div :class="$style.floorName">
-        <span :class="$style.floorNameText">{{ group.name }}</span>
-      </div>
-      <div :class="$style.roomGrid">
-        <v-card
-          v-for="room in group.rooms"
-          :key="room.id"
-          elevation="0"
-          :color="isMyRoom(room) ? 'primary' : 'primaryLight'"
-          class="ma-2 pa-2"
-          :class="$style.card"
-        >
-          <div class="h-100 position-relative d-flex flex-column justify-center">
-            <v-card-title class="text-center pa-0">
-              <span
-                :class="$style.roomName"
-                :style="{ color: isMyRoom(room) ? 'white' : 'rgb(var(--v-theme-primary))' }"
+  <div class="position-relative w-100 h-100">
+    <div
+      v-if="roomGroups.length === 0"
+      class="d-flex flex-column align-center justify-center w-100 h-100"
+    >
+      <v-icon size="64" class="mb-2" icon="mdi-view-grid" />
+      <h3 class="font-weight-bold">{{ displayCamp.name }}の部屋割は未定です</h3>
+    </div>
+    <div v-else :class="$style.content">
+      <div v-for="group in roomGroups" :key="group.id" class="d-flex flex-column align-center">
+        <div :class="$style.floorName">
+          <span :class="$style.floorNameText">{{ group.name }}</span>
+        </div>
+        <div :class="$style.roomGrid">
+          <v-card
+            v-for="room in group.rooms"
+            :key="room.id"
+            elevation="0"
+            :color="isMyRoom(room) ? 'primary' : 'primaryLight'"
+            class="ma-2 pa-2"
+            :class="$style.card"
+          >
+            <div class="h-100 position-relative d-flex flex-column justify-center">
+              <v-card-title class="text-center pa-0">
+                <span
+                  :class="$style.roomName"
+                  :style="{ color: isMyRoom(room) ? 'white' : 'rgb(var(--v-theme-primary))' }"
+                >
+                  {{ room.name }}
+                </span>
+              </v-card-title>
+              <div
+                v-if="isMyRoom(room)"
+                class="w-100 h-100 d-flex flex-wrap justify-center align-center"
               >
-                {{ room.name }}
-              </span>
-            </v-card-title>
-            <div
-              v-if="isMyRoom(room)"
-              class="w-100 h-100 d-flex flex-wrap justify-center align-center"
-            >
-              <user-icon :id="userStore.user.id" :size="26" class="ma-1" :class="$style.userIcon" />
-              <user-icon
-                v-for="user in room.members.filter((u) => u.id !== userStore.user.id)"
-                :id="user.id"
-                :key="user.id"
-                :size="26"
-                class="ma-1"
-              />
+                <user-icon
+                  :id="userStore.user.id"
+                  :size="26"
+                  class="ma-1"
+                  :class="$style.userIcon"
+                />
+                <user-icon
+                  v-for="user in room.members.filter((u) => u.id !== userStore.user.id)"
+                  :id="user.id"
+                  :key="user.id"
+                  :size="26"
+                  class="ma-1"
+                />
+              </div>
+              <div v-else class="w-100 h-100 d-flex flex-wrap justify-center align-center">
+                <user-icon
+                  v-for="user in room.members"
+                  :id="user.id"
+                  :key="user.id"
+                  :size="26"
+                  class="ma-1"
+                />
+              </div>
             </div>
-            <div v-else class="w-100 h-100 d-flex flex-wrap justify-center align-center">
-              <user-icon
-                v-for="user in room.members"
-                :id="user.id"
-                :key="user.id"
-                :size="26"
-                class="ma-1"
-              />
-            </div>
-          </div>
-        </v-card>
+          </v-card>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style module>
-.container {
+.content {
   position: relative;
   max-width: 600px;
   margin: 0 auto;


### PR DESCRIPTION
まだ確定していない点が 2 つありますが、旧 rucQ に準えるとここまでの分だけで一応完結しているので PR 投げちゃいます
- 部屋ごとのメンバー表示ダイアログを出すか？ → https://github.com/traPtitech/rucQ-UI/pull/88 のマージによって不要になる可能性があります
- Figma 上のデザイン通りギャラリーをこのページに含めるか？ → 含めるとして、画像表示のための（部分的に拡大できたりするような）UI はまた別の仕事にした方がよさそう