### PR TITLE
キャッシュを正しく待機して読み込む

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -5,7 +5,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import localforage from 'localforage'
 
 // キャッシュの設定
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       gcTime: 7 * 24 * 60 * 60 * 1000, // 1週間
@@ -18,10 +18,11 @@ const asyncPersister = createAsyncStoragePersister({
   storage: localforage,
 })
 
-export const queryCacheReady = async () =>
-  persistQueryClient({
-    queryClient,
-    persister: asyncPersister,
-    maxAge: 7 * 24 * 60 * 60 * 1000, // 永続化キャッシュの寿命
-    buster: __APP_VERSION__, // package.json のバージョンを自動反映
-  })
+const [, restorePromise] = persistQueryClient({
+  queryClient,
+  persister: asyncPersister,
+  maxAge: 7 * 24 * 60 * 60 * 1000, // 永続化キャッシュの寿命
+  buster: __APP_VERSION__, // package.json のバージョンを自動反映
+})
+
+export { queryClient, restorePromise }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import router from '@/router'
 import { createPinia } from 'pinia'
 import { VueQueryPlugin } from '@tanstack/vue-query'
 import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
-import { queryClient, queryCacheReady } from '@/lib/queryClient'
+import { queryClient, restorePromise } from '@/lib/queryClient'
 import { vuetify } from '@/lib/vuetify'
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
@@ -36,7 +36,7 @@ async function initializeApp() {
   }
 
   try {
-    await queryCacheReady() // キャッシュの読み込み
+    await restorePromise // キャッシュの読み込み
     const userStore = useUserStore()
     const campStore = useCampStore()
     await userStore.initUser()


### PR DESCRIPTION
#127, #155 に関連しています
- persistQueryClient の返り値の二が永続化されたキャッシュの復元完了を待つ promise であるという仕様を信頼し、マウント前に await することでオフライン状況下で画面の描画に失敗する問題の解決を図っています
- よく調べると `<PersistQueryClientProvider>` は React だけに提供されるコンポーネントだったので採用しませんでした