### PR TITLE
プレビュービルドのアーキテクチャを amd64 に限定

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -22,8 +22,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -40,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 # amd64 のみ
           push: true
           tags: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:preview-${{ env.PR_NUMBER }}-${{ github.event.pull_request.head.sha }}
           cache-from: type=registry,ref=ghcr.io/traptitech/${{ env.IMAGE_NAME }}:buildcache


### PR DESCRIPTION
最近のプレビュービルドに関する以下のような問題
- とても時間がかかる（最低でも7分）
- 頻繁に落ちる（実行中の表示のまま数時間固まる）

QEMU を用いてマルチアーキテクチャのイメージをビルドしていることが原因である可能性があるので、amd64 のみのビルドに限定してみます