### PR TITLE
アクセス発生時に必ず sw.js と index.html を更新

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,13 +4,13 @@
 	route {
 		root * /usr/share/caddy
 
-		@noCache {
-			path /sw.js
-			path /registerSW.js
-			path /manifest.webmanifest
-			path /index.html
+		# デフォルトで HTTP Cache を無効化
+		header Cache-Control "no-cache, no-store, must-revalidate"
+
+		@assets {
+			path /assets/*
 		}
-		header @noCache Cache-Control "no-cache, no-store, must-revalidate"
+		header @assets Cache-Control "max-age=31536000, immutable"
 
 		try_files {path} /index.html
 		file_server {


### PR DESCRIPTION
従来の Caddyfile ではファイルの HTTP Cache についてとくに定めておらず、Heuristic Caching により sw.js がアクセス時に必ずしも更新されない可能性がありました

sw.js をはじめとする「ビルド成果物に含まれるハッシュのつかないコードファイル」を全てキャッシュさせないよう Caddyfile の設定を更新してみます