### PR TITLE
router を使用して /login に遷移

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,9 @@ import type { components } from '@/api/schema'
 import { apiClient } from '@/api/apiClient'
 import { useQueryClient } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
 
 type User = components['schemas']['UserResponse']
 type Camp = components['schemas']['CampResponse']
@@ -22,7 +25,7 @@ export const useUserStore = defineStore('user', () => {
 
         // Temporary Redirect の場合、手動でリダイレクト処理を行う
         if (response.type === 'opaqueredirect') {
-          window.location.href = '/login'
+          await router.replace('/login')
           return new Promise<never>(() => {
             // ユーザーにエラー表示をさせないよう、解決しない Promise を返す
           })


### PR DESCRIPTION
#197 にてダメもとで /login へのリダイレクトを router.replace にしてみたらなぜかうまくいったので新規に PR を作成
リロードを経由しなければ Cookie の鮮度が失われない、とかなのかな？

<details>
<summary>現在発生している問題についてのまとめ</summary>
_

1. ページを開いた状態でキャッシュを消してリロード
2. / → /login → https://q.trap.jp/api/v3/oauth2/authorize → https://auth.trapti.tech/_oauth とリダイレクトされる
3. 最終的に Not Authorized と表示される
4. 以降 / にアクセスすると Not Authorized にリダイレクトされて rucQ の画面を見られない

補足
- VitePWA 自体を無効化してサービスワーカーを削除した rucQ ではサイレントログインが働いて Cookie が復活するだけ
- 手動で Cookie を削除する操作はなかなかイレギュラーだが、Cookie が切れたときに同様のことが発生する懸念がある

</details>