### PR TITLE
リダイレクトを manual で統一する

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,4 @@
 import createClient from 'openapi-fetch'
 import type { paths } from '@/api/schema'
 
-export const apiClient = createClient<paths>()
+export const apiClient = createClient<paths>({ redirect: 'manual' })

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,9 +16,7 @@ export const useUserStore = defineStore('user', () => {
     const data = await queryClient.ensureQueryData({
       queryKey: qk.me.all,
       queryFn: async () => {
-        const { data, error, response } = await apiClient.GET('/api/me', {
-          redirect: 'manual',
-        })
+        const { data, error, response } = await apiClient.GET('/api/me')
 
         // Temporary Redirect の場合、手動でリダイレクト処理を行う
         if (response.type === 'opaqueredirect') {


### PR DESCRIPTION
他の manual でないリダイレクトに Cookie 情報が邪魔をされているのでは？ という推測

<details>
<summary>現在発生している問題についてのまとめ</summary>
_

1. ページを開いた状態でキャッシュを消してリロード
2. / → /login → https://q.trap.jp/api/v3/oauth2/authorize → https://auth.trapti.tech/_oauth とリダイレクトされる
3. 最終的に Not Authorized と表示される
4. 以降 / にアクセスすると Not Authorized にリダイレクトされて rucQ の画面を見られない

補足
- VitePWA 自体を無効化してサービスワーカーを削除した rucQ ではサイレントログインが働いて Cookie が復活するだけ
- 手動で Cookie を削除する操作はなかなかイレギュラーだが、Cookie が切れたときに同様のことが発生する懸念がある

</details>