### PR TITLE
MarkdownPreview の二重スクロール問題を解消

### DIFF
--- a/src/components/markdown/MarkdownPreview.vue
+++ b/src/components/markdown/MarkdownPreview.vue
@@ -133,10 +133,7 @@ onMounted(() => {
 
 <style module>
 .content {
-  width: 100%;
-  height: 100%;
   z-index: -1;
-  overflow-y: hidden;
 }
 
 .preview {


### PR DESCRIPTION
MarkdownPreview の内側にスクロールバーが表示される問題は解消されているはず
手元の Android 端末に接続して試しました