### PR TITLE
rucQ アイコンに明示的な width と height を指定

### DIFF
--- a/src/components/layout/HeaderButton.vue
+++ b/src/components/layout/HeaderButton.vue
@@ -10,7 +10,13 @@ const { xs } = useDisplay()
 <template>
   <v-app-bar v-if="xs" elevation="2" color="white" density="comfortable" :class="$style.appBar">
     <template #prepend>
-      <img src="/icons/icon-transparent.svg" alt="rucQ Icon" :class="$style.icon" />
+      <img
+        src="/icons/icon-transparent.svg"
+        alt="rucQ Icon"
+        width="44"
+        height="44"
+        :class="$style.icon"
+      />
     </template>
     <v-app-bar-title class="text-primary">
       <span :class="$style.routeTitle">{{ route.name }}</span>
@@ -41,7 +47,6 @@ const { xs } = useDisplay()
 
 <style module>
 .icon {
-  height: 80%;
   margin-right: 6px;
 }
 


### PR DESCRIPTION
iOS / macOS の Safari にて図のように正しくページタイトルとボタンが表示されなくなるバグ（以下）があったので、これを解決
rucQ アイコンの画像の横幅を明示していなかったため正しく解釈されなかったことが原因だと思われる

<img width="1144" height="183" alt="名称未設定" src="https://github.com/user-attachments/assets/d52a3227-aa7f-4f62-803a-8eede0980fdf" />