### PR TITLE
EventGrid の見た目を微調整

### DIFF
--- a/src/components/event/utils/eventGrid.ts
+++ b/src/components/event/utils/eventGrid.ts
@@ -156,7 +156,7 @@ export class DayEventGrid {
         return event.id !== lastEvent.id
       })
 
-      if (isSeparated) {
+      if (isSeparated && currentGroup.length > 0) {
         groups.push(this.exportGroup(currentGroup))
         currentGroup = []
       }


### PR DESCRIPTION
時刻同士の間隔の計算方法にバグがあり、横点線のすぐ後ろの時刻に瞬間イベントがあるとき瞬間イベントの手前が必要以上に広く表示されてしまっていたので修正

言語化がむずかしいのだけれど、ここのプレビュービルドと本番の rucQ を見比べてもらえれば何がしたかったのかはなんとなくわかってもらえるはず

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

**バグ修正**
- イベントグリッドの空領域と隣接行の高さ調整を改善し、空行が直前行の表示を崩すケースを軽減しました。  
- エクスポート時の行グループ化ロジックを改良し、各列のイベント差分に基づいて区切り判定を行うことで、連続イベントのまとまりがより正確に出力されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->