### PR TITLE
回答のキャッシュを誤って無効化していた問題を修正

### DIFF
--- a/src/components/information/QuestionGroupPanel.vue
+++ b/src/components/information/QuestionGroupPanel.vue
@@ -54,11 +54,6 @@ const originalMap = reactive<Record<number, AnswerData>>({})
 
 // getMyAnswers の結果をリアクティブ変数 answersMap に格納する
 const refreshAnswersMap = async () => {
-  // 回答取得クエリキーを invalidate
-  await queryClient.invalidateQueries({
-    queryKey: qk.me.questionGroupAnswers(props.questionGroup.id),
-  })
-
   for (const question of props.questionGroup.questions) {
     switch (question.type) {
       case 'free_text':
@@ -225,11 +220,15 @@ const saveAnswersMutation = useMutation({
     }
   },
   onSuccess: async () => {
+    // 回答を保存した後は必ず最新データを取得するために invalidate
+    await queryClient.invalidateQueries({
+      queryKey: qk.me.questionGroupAnswers(props.questionGroup.id),
+    })
     await quitEditMode()
   },
 })
 
-onMounted(refreshAnswersMap)
+onMounted(refreshAnswersMap) // 初回はクエリの invalidate を行わない
 </script>
 
 <template>


### PR DESCRIPTION
closes https://github.com/traPtitech/rucQ-UI/issues/176

これまで
- 初回読み込み時
- 回答編集を保存せず終了した時
- 回答編集を保存して終了した時

の全てで quitEditMode > refreshAnswersMap > invalidateQueries の呼び出しが生じており、これが「ユーザー情報ページを開くたびに新規に回答の読み込みが発生する問題」の原因になっていました

「回答編集を保存して終了した時」のみ invalidateQueries を実行するようコードを修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * 回答データの更新ロジックを最適化しました。初期読み込み時の不要なデータ再取得を削除し、回答保存後により効率的にデータを更新するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->