### PR TITLE
MarkdownPreview における HTML の二重パースを解消

### DIFF
--- a/src/components/markdown/MarkdownPreview.vue
+++ b/src/components/markdown/MarkdownPreview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
+import { md } from '@/utils/markdown'
 
 type HeadingInfo = {
   id: string
@@ -15,11 +15,6 @@ const props = defineProps<{
 
 const headings = defineModel<HeadingInfo[]>('headings')
 const htmltext = ref('')
-
-const md = new MarkdownIt({
-  breaks: true,
-  linkify: true,
-})
 
 // mdtext 変更時に HTML と見出し情報を更新
 watch(

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,7 @@
+import MarkdownIt from 'markdown-it'
+
+// 再利用可能な MarkdownIt インスタンス
+export const md = new MarkdownIt({
+  breaks: true,
+  linkify: true,
+})


### PR DESCRIPTION
緊急ではありません　あとブランチ名はうそです

MarkdownPreview.vue において DOMPurify.sanitize の結果（HTML テキスト）を再度パースして見出しを見つける無駄な処理が走っていたので、DOMPurify から DOM を返させて見出し探しに利用することでパースを 1 回にします

また、大した効果はないと思うけれど MarkdownIt インスタンスを utils/markdown.ts に引っ越してコンポーネント毎に作成されないようにすることでメモリ効率を少しだけ上げた（かもしれない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * マークダウンレンダリング処理を統一ユーティリティに移行し、内部実装を効率化しました。
  * DOM処理の最適化により、マークダウン表示のパフォーマンスと安定性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->