### PR TITLE
点呼画面をラジオボタン式に切り替え

### DIFF
--- a/src/views/RollCallView.vue
+++ b/src/views/RollCallView.vue
@@ -92,11 +92,7 @@ const channelUrl = computed(() => `https://q.trap.jp/channels/${import.meta.env.
       <div v-if="!isSubject" :class="[$style.notSubject, 'text-primary']">点呼の対象外です</div>
     </div>
     <div :class="$style.body">
-      <v-radio-group
-        :disabled="!isSubject"
-        :model-value="myReaction?.content"
-        @update:model-value="handleRadioChange"
-      >
+      <v-radio-group :model-value="myReaction?.content" @update:model-value="handleRadioChange">
         <v-card
           v-for="opt in grouped.options"
           :key="opt.name"
@@ -106,7 +102,7 @@ const channelUrl = computed(() => `https://q.trap.jp/channels/${import.meta.env.
           :color="myReaction?.content === opt.name ? 'primary' : 'white'"
         >
           <v-card-text class="d-flex justify-space-between py-3 px-2">
-            <v-radio color="white" :value="opt.name" />
+            <v-radio color="white" :value="opt.name" :disabled="!isSubject" />
             <user-response
               :title="opt.name"
               :user-ids="opt.ids"


### PR DESCRIPTION
点呼画面をラジオボタン式に切り替えました
当たり判定の小さいラジオボタンでリアクションを切り替えることで、誤操作の減少が期待できます

追記：この部分のデザインに関しては固まっていなかったような記憶があるのでまたデザインし直す可能性がありますが、一旦次の合宿で誤操作問題だけなんとかしようという考えです

テスト用：https://217-prod.rucq-ui-preview.trapti.tech/camp25summer/rollcall/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * オプション選択をカード内のラジオボタン方式に刷新し、選択状態がより明確に表示されます。
  * ラジオ選択は無効状態を尊重して適切に処理され、誤操作を防止します。
  * 選択に応じてカードの表示色やテキストが同期的に更新され、一貫性と読みやすさが向上しました。
  * レイアウトを横並びに調整し、ラジオと内容の配置や余白が最適化されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->