### PR TITLE
更新されていない場合は更新ボタンをdisable

### DIFF
--- a/src/components/room/RoomStatusDialog.vue
+++ b/src/components/room/RoomStatusDialog.vue
@@ -65,6 +65,12 @@ const getStatusColor = (type: RoomStatus['type']) => {
 // 64 文字制限。超えると Bad Request
 const isWordTooLong = computed(() => Array.from(word.value).length > 64)
 
+const isDisabled = computed(() => {
+  const statusChanged = status.value !== props.room.status.type
+  const topicChanged = word.value !== props.room.status.topic
+  return isWordTooLong.value || (!statusChanged && !topicChanged)
+})
+
 const updateStatus = async () => {
   const { error } = await apiClient.PUT('/api/rooms/{roomId}/status', {
     params: { path: { roomId: props.room.id } },
@@ -145,13 +151,7 @@ const updateStatus = async () => {
         </div>
       </div>
     </v-expand-transition>
-    <v-btn
-      class="mt-2"
-      variant="flat"
-      color="primary"
-      :disabled="isWordTooLong"
-      @click="updateStatus"
-    >
+    <v-btn class="mt-2" variant="flat" color="primary" :disabled="isDisabled" @click="updateStatus">
       更新
     </v-btn>
   </v-card>


### PR DESCRIPTION
closes https://github.com/traPtitech/rucQ-UI/issues/228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ルームステータスの更新ボタンの有効/無効状態を改善しました。入力が64文字を超えた場合、またはステータスやトピックに実際の変更がない場合、更新ボタンが無効になるようになりました。これにより、実際の変更があった場合のみ更新が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->