### PR TITLE
API自動生成型のエイリアス定義をtypeAliases.tsに集約

### DIFF
--- a/src/components/activity/QuestionActivity.vue
+++ b/src/components/activity/QuestionActivity.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import ActivityLayout from '@/components/activity/ActivityLayout.vue'
-import type { components } from '@/api/schema'
 import { getJSTDate, getMonthDayStringNoPad } from '@/utils/date'
-
-type QuestionCreatedActivity = components['schemas']['QuestionCreatedActivity']
+import type { QuestionCreatedActivity } from '@/typeAliases'
 
 defineProps<{
   activity: QuestionCreatedActivity

--- a/src/components/activity/RollCallActivity.vue
+++ b/src/components/activity/RollCallActivity.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import ActivityLayout from '@/components/activity/ActivityLayout.vue'
-import type { components } from '@/api/schema'
 import { useRoute } from 'vue-router'
-
-type RollCallCreatedActivity = components['schemas']['RollCallCreatedActivity']
+import type { RollCallCreatedActivity } from '@/typeAliases'
 
 const route = useRoute()
 

--- a/src/components/event/EventBlock.vue
+++ b/src/components/event/EventBlock.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { components } from '@/api/schema'
 import EventDialog from './EventDialog.vue'
+import type { DurationEvent, OfficialEvent } from '@/typeAliases'
 
-type DurationEvent = components['schemas']['DurationEventResponse']
-type OfficialEvent = components['schemas']['OfficialEventResponse']
 const props = defineProps<{ event: DurationEvent | OfficialEvent }>()
 
 const eventColor = computed(() => {

--- a/src/components/event/EventDialog.vue
+++ b/src/components/event/EventDialog.vue
@@ -3,9 +3,9 @@ import { computed } from 'vue'
 import MarkdownPreview from '@/components/markdown/MarkdownPreview.vue'
 import UserIcon from '@/components/generic/UserIcon.vue'
 import { getTimeStringNoPad } from '@/utils/date'
-import type { components } from '@/api/schema'
 import { useCampStore } from '@/store'
 import { useRoute } from 'vue-router'
+import type { CampEvent } from '@/typeAliases'
 
 const emit = defineEmits(['edit', 'close'])
 
@@ -20,7 +20,6 @@ const isOperable = computed(() => {
   return campStore.isOperable(displayCamp.value)
 })
 
-type CampEvent = components['schemas']['EventResponse']
 const props = defineProps<{ event: CampEvent; color: string }>()
 
 // イベントの時刻に関する文字列

--- a/src/components/event/EventEditor.vue
+++ b/src/components/event/EventEditor.vue
@@ -7,10 +7,10 @@ const { smAndDown } = useDisplay()
 import { apiClient } from '@/api/apiClient'
 import { useCampStore, useUserStore } from '@/store'
 import { useRoute } from 'vue-router'
-import type { components } from '@/api/schema'
 import { dateToText, dateDiffInDaysJST, getJSTDate } from '@/utils/date'
 import { EVENT_COLORS } from '@/components/event/utils/eventColors'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import type { DurationEvent, DurationEventRequest } from '@/typeAliases'
 
 import { qk } from '@/api/queries/keys'
 
@@ -27,7 +27,6 @@ const displayCamp = computed(() => {
 const emit = defineEmits(['close'])
 
 // rucQ-UI で編集可能なのは DurationEvent のみ。他は rucQ-Admin で編集
-type DurationEvent = components['schemas']['DurationEventResponse']
 const props = defineProps<{ event: DurationEvent | null }>()
 
 const isValid = computed(() => {
@@ -117,7 +116,7 @@ onMounted(() => {
 
 // Mutations
 const upsertEventMutation = useMutation({
-  mutationFn: async (body: components['schemas']['DurationEventRequest']) => {
+  mutationFn: async (body: DurationEventRequest) => {
     if (props.event) {
       const { error } = await apiClient.PUT('/api/events/{eventId}', {
         params: { path: { eventId: props.event.id } },

--- a/src/components/event/EventEditorSettings.vue
+++ b/src/components/event/EventEditorSettings.vue
@@ -3,13 +3,10 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { getDayStringNoPad } from '@/utils/date'
 import EventTimePick from './EventTimePick.vue'
 import EventDeleteDialog from './EventDeleteDialog.vue'
-import type { components } from '@/api/schema'
 import { apiClient } from '@/api/apiClient'
 import UserIcon from '@/components/generic/UserIcon.vue'
 import { EVENT_COLORS } from '@/components/event/utils/eventColors'
-
-type DurationEvent = components['schemas']['DurationEventResponse']
-type Camp = components['schemas']['CampResponse']
+import type { Camp, DurationEvent } from '@/typeAliases'
 
 const props = defineProps<{ event: DurationEvent | null; camp: Camp }>()
 const emit = defineEmits(['delete'])

--- a/src/components/event/EventTimePick.vue
+++ b/src/components/event/EventTimePick.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import { nextTick, ref, watch, onMounted } from 'vue'
 import type { VTextField } from 'vuetify/components'
+import type { DurationEvent } from '@/typeAliases'
 
-type DurationEvent = components['schemas']['DurationEventResponse']
 type EventColor = DurationEvent['displayColor']
 
 const textFieldRef = ref<VTextField>()

--- a/src/components/event/ScheduleContent.vue
+++ b/src/components/event/ScheduleContent.vue
@@ -3,14 +3,10 @@ import { computed, ref } from 'vue'
 import { getDayStringNoPad } from '@/utils/date'
 import { getLayout } from '@/components/event/utils/eventLayout'
 import EventBlock from '@/components/event/EventBlock.vue'
-import type { components } from '@/api/schema'
 import type { EventGroup, DurationEventPos } from '@/components/event/utils/eventGrid'
 import EventEditor from './EventEditor.vue'
 import ScheduleRow from './ScheduleRow.vue'
-
-type CampEvent = components['schemas']['EventResponse']
-type DurationEvent = components['schemas']['DurationEventResponse']
-type Camp = components['schemas']['CampResponse']
+import type { Camp, CampEvent, DurationEvent } from '@/typeAliases'
 
 const props = defineProps<{
   events: CampEvent[]

--- a/src/components/event/utils/eventColors.ts
+++ b/src/components/event/utils/eventColors.ts
@@ -1,7 +1,5 @@
 // イベントで利用可能な色の定義
-import type { components } from '@/api/schema'
-
-type DurationEvent = components['schemas']['DurationEventResponse']
+import type { DurationEvent } from '@/typeAliases'
 
 // 型から色の配列を定義することはできないため、手動で定義
 export const EVENT_COLORS: DurationEvent['displayColor'][] = [

--- a/src/components/event/utils/eventGrid.ts
+++ b/src/components/event/utils/eventGrid.ts
@@ -1,10 +1,5 @@
-import type { components } from '@/api/schema'
 import { getStartTime, getEndTime } from '@/components/event/utils/eventLib'
-
-type MomentEvent = components['schemas']['MomentEventResponse']
-type DurationEvent = components['schemas']['DurationEventResponse']
-type OfficialEvent = components['schemas']['OfficialEventResponse']
-type CampEvent = MomentEvent | DurationEvent | OfficialEvent
+import type { CampEvent, DurationEvent, MomentEvent, OfficialEvent } from '@/typeAliases'
 
 export type GridRow = {
   time: Date

--- a/src/components/event/utils/eventLayout.ts
+++ b/src/components/event/utils/eventLayout.ts
@@ -1,13 +1,7 @@
-import type { components } from '@/api/schema'
 import { DayEventGrid, type EventGroup } from '@/components/event/utils/eventGrid'
 import { getStartTime, getEndTime } from '@/components/event/utils/eventLib'
 import { getJSTDate } from '@/utils/date'
-
-type Camp = components['schemas']['CampResponse']
-type MomentEvent = components['schemas']['MomentEventResponse']
-type DurationEvent = components['schemas']['DurationEventResponse']
-type OfficialEvent = components['schemas']['OfficialEventResponse']
-type CampEvent = MomentEvent | DurationEvent | OfficialEvent
+import type { Camp, CampEvent } from '@/typeAliases'
 
 export type DayEventGroups = {
   date: Date

--- a/src/components/event/utils/eventLib.ts
+++ b/src/components/event/utils/eventLib.ts
@@ -1,5 +1,4 @@
-import type { components } from '@/api/schema'
-type CampEvent = components['schemas']['EventResponse']
+import type { CampEvent } from '@/typeAliases'
 
 // イベントの開始時刻（瞬間イベントならその時刻）を返す
 export const getStartTime = (event: CampEvent) => {

--- a/src/components/information/AnswersDialog.vue
+++ b/src/components/information/AnswersDialog.vue
@@ -5,12 +5,9 @@ import { apiClient } from '@/api/apiClient'
 import { qk } from '@/api/queries/keys'
 import { useQueries } from '@tanstack/vue-query'
 import AnswersDialogContent from './AnswersDialogContent.vue'
-import type { components } from '@/api/schema'
-const { xs } = useDisplay()
+import type { QuestionGroup, Question, Answer } from '@/typeAliases'
 
-type QuestionGroup = components['schemas']['QuestionGroupResponse']
-type Question = components['schemas']['QuestionResponse']
-type AnswerResponse = components['schemas']['AnswerResponse']
+const { xs } = useDisplay()
 
 const props = defineProps<{
   questionGroup: QuestionGroup
@@ -19,7 +16,7 @@ const props = defineProps<{
 const openPanel = ref<number | undefined>(0)
 
 // 与えられた質問に対する回答を回答テキスト別 ID の配列として整形
-const mapAnswersByContent = (question: Question, data: AnswerResponse[]) => {
+const mapAnswersByContent = (question: Question, data: Answer[]) => {
   const byAnswer: Record<string, string[]> = {}
 
   switch (question.type) {

--- a/src/components/information/AnswersDialogContent.vue
+++ b/src/components/information/AnswersDialogContent.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import { useDisplay } from 'vuetify'
 import UserIcon from '@/components/generic/UserIcon.vue'
-const { xs } = useDisplay()
+import type { Question } from '@/typeAliases'
 
-type Question = components['schemas']['QuestionResponse']
+const { xs } = useDisplay()
 
 defineProps<{
   question: Question

--- a/src/components/information/PaymentInfo.vue
+++ b/src/components/information/PaymentInfo.vue
@@ -1,8 +1,6 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import type { components } from '@/api/schema'
-
-type Payment = components['schemas']['PaymentResponse']
+import type { Payment } from '@/typeAliases'
 
 const props = defineProps<{ isReady: boolean; payment?: Payment }>()
 

--- a/src/components/information/QuestionEditField.vue
+++ b/src/components/information/QuestionEditField.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
-
-type Question = components['schemas']['QuestionResponse']
+import type { Question } from '@/typeAliases'
 
 defineProps<{ question: Question }>()
 const value = defineModel<string | number | number[]>('value')

--- a/src/components/information/QuestionGroupEditor.vue
+++ b/src/components/information/QuestionGroupEditor.vue
@@ -1,13 +1,10 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import QuestionEditField from '@/components/information/QuestionEditField.vue'
 import MarkdownPreview from '@/components/markdown/MarkdownPreview.vue'
 import AnswersDialog from '@/components/information/AnswersDialog.vue'
 import { computed } from 'vue'
 import { getDayString } from '@/utils/date'
-
-type QuestionGroup = components['schemas']['QuestionGroupResponse']
-type Question = components['schemas']['QuestionResponse']
+import type { QuestionGroup, Question } from '@/typeAliases'
 
 type AnswerData = { id?: number; value?: number | string | number[] }
 

--- a/src/components/information/QuestionGroupPanel.vue
+++ b/src/components/information/QuestionGroupPanel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import { apiClient } from '@/api/apiClient'
 import { ref, computed, onMounted, reactive, toRaw } from 'vue'
 import { useCampStore } from '@/store'
@@ -7,10 +6,7 @@ import QuestionGroupEditor from '@/components/information/QuestionGroupEditor.vu
 import QuestionGroupViewer from '@/components/information/QuestionGroupViewer.vue'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
-
-type QuestionGroup = components['schemas']['QuestionGroupResponse']
-type Question = components['schemas']['QuestionResponse']
-type Camp = components['schemas']['CampResponse']
+import type { QuestionGroup, Question, Camp } from '@/typeAliases'
 
 const queryClient = useQueryClient()
 

--- a/src/components/information/QuestionGroupViewer.vue
+++ b/src/components/information/QuestionGroupViewer.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import QuestionShowField from '@/components/information/QuestionShowField.vue'
 import { computed } from 'vue'
 import AnswersDialog from '@/components/information/AnswersDialog.vue'
-
-type QuestionGroup = components['schemas']['QuestionGroupResponse']
-type Question = components['schemas']['QuestionResponse']
+import type { QuestionGroup, Question } from '@/typeAliases'
 
 type AnswerData = { id?: number; value?: number | string | number[] }
 

--- a/src/components/information/QuestionShowField.vue
+++ b/src/components/information/QuestionShowField.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import { computed } from 'vue'
-
-type Question = components['schemas']['QuestionResponse']
+import type { Question } from '@/typeAliases'
 
 const props = defineProps<{
   question: Question

--- a/src/components/information/RoomInfo.vue
+++ b/src/components/information/RoomInfo.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import UserIcon from '@/components/generic/UserIcon.vue'
 import { useUserStore } from '@/store'
-
-type Room = components['schemas']['RoomResponse']
+import type { Room } from '@/typeAliases'
 
 const userStore = useUserStore()
 

--- a/src/components/rollcall/rollCallStream.ts
+++ b/src/components/rollcall/rollCallStream.ts
@@ -1,12 +1,8 @@
 import { ref, computed, type Ref } from 'vue'
 import { apiClient } from '@/api/apiClient'
-import type { components } from '@/api/schema'
+import type { RollCall, RollCallReaction, RollCallReactionEvent } from '@/typeAliases'
 
 // 同一ユーザーが複数リアクションを送信していない前提
-
-type RollCallReactionEvent = components['schemas']['RollCallReactionEvent']
-type RollCall = components['schemas']['RollCallResponse']
-type RollCallReaction = components['schemas']['RollCallReactionResponse']
 
 // 点呼リアクションの SSE 購読
 const listenRollCallReactions = (

--- a/src/components/room/RoomCard.vue
+++ b/src/components/room/RoomCard.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import type { components } from '@/api/schema'
 import RoomStatusDialog from '@/components/room/RoomStatusDialog.vue'
 import UserIcon from '@/components/generic/UserIcon.vue'
 import { useUserStore } from '@/store'
 import { computed } from 'vue'
-
-type Room = components['schemas']['RoomResponse']
+import type { Room } from '@/typeAliases'
 
 const props = defineProps<{
   room: Room

--- a/src/components/room/RoomStatusDialog.vue
+++ b/src/components/room/RoomStatusDialog.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import type { components } from '@/api/schema'
 import { apiClient } from '@/api/apiClient'
 import UserIcon from '@/components/generic/UserIcon.vue'
 import { useQuery, useQueryClient } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
 import { getDisplayDate } from '@/utils/date'
-
-type Room = components['schemas']['RoomResponse']
-type RoomStatus = components['schemas']['RoomStatus']
-type RoomStatusLog = components['schemas']['RoomStatusLog']
+import type { Room, RoomStatus, RoomStatusLog } from '@/typeAliases'
 
 const props = defineProps<{
   room: Room

--- a/src/mocks/activities.ts
+++ b/src/mocks/activities.ts
@@ -1,8 +1,6 @@
-import type { components } from '@/api/schema'
+import type { Activity } from '@/typeAliases'
 
-type ActivityResponse = components['schemas']['ActivityResponse']
-
-export const activities: ActivityResponse[] = [
+export const activities: Activity[] = [
   {
     id: 1,
     type: 'room_created',

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,12 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import type { components } from '@/api/schema'
 import { apiClient } from '@/api/apiClient'
 import { useQueryClient } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
-
-type User = components['schemas']['UserResponse']
-type Camp = components['schemas']['CampResponse']
+import type { User, Camp } from '@/typeAliases'
 
 export const useUserStore = defineStore('user', () => {
   const user = ref<User>()
@@ -73,18 +70,16 @@ export const useCampStore = defineStore('camp', () => {
     allCamps.value = camps
     latestCamp.value = allCamps.value[0]!
 
-    const participants = await queryClient.ensureQueryData<components['schemas']['UserResponse'][]>(
-      {
-        queryKey: qk.camps.participants(latestCamp.value.id),
-        queryFn: async () => {
-          const { data, error } = await apiClient.GET('/api/camps/{campId}/participants', {
-            params: { path: { campId: latestCamp.value!.id } },
-          })
-          if (error) throw new Error(`合宿参加者情報の取得に失敗しました: ${error.message}`)
-          return data
-        },
+    const participants = await queryClient.ensureQueryData<User[]>({
+      queryKey: qk.camps.participants(latestCamp.value.id),
+      queryFn: async () => {
+        const { data, error } = await apiClient.GET('/api/camps/{campId}/participants', {
+          params: { path: { campId: latestCamp.value!.id } },
+        })
+        if (error) throw new Error(`合宿参加者情報の取得に失敗しました: ${error.message}`)
+        return data
       },
-    )
+    })
     hasRegisteredLatest.value = participants.some((user) => user.id === me.id)
   }
 

--- a/src/typeAliases.ts
+++ b/src/typeAliases.ts
@@ -1,0 +1,30 @@
+import type { components } from '@/api/schema'
+
+export type User = components['schemas']['UserResponse']
+export type Camp = components['schemas']['CampResponse']
+
+export type CampEvent = components['schemas']['EventResponse']
+export type MomentEvent = components['schemas']['MomentEventResponse']
+export type DurationEvent = components['schemas']['DurationEventResponse']
+export type OfficialEvent = components['schemas']['OfficialEventResponse']
+export type DurationEventRequest = components['schemas']['DurationEventRequest']
+
+export type QuestionGroup = components['schemas']['QuestionGroupResponse']
+export type Question = components['schemas']['QuestionResponse']
+export type Answer = components['schemas']['AnswerResponse']
+export type QuestionCreatedActivity = components['schemas']['QuestionCreatedActivity']
+
+export type Dashboard = components['schemas']['DashboardResponse']
+export type Payment = components['schemas']['PaymentResponse']
+
+export type RoomGroup = components['schemas']['RoomGroupResponse']
+export type Room = components['schemas']['RoomResponse']
+export type RoomStatus = components['schemas']['RoomStatus']
+export type RoomStatusLog = components['schemas']['RoomStatusLog']
+
+export type Activity = components['schemas']['ActivityResponse']
+
+export type RollCall = components['schemas']['RollCallResponse']
+export type RollCallReaction = components['schemas']['RollCallReactionResponse']
+export type RollCallReactionEvent = components['schemas']['RollCallReactionEvent']
+export type RollCallCreatedActivity = components['schemas']['RollCallCreatedActivity']

--- a/src/views/ActivityView.vue
+++ b/src/views/ActivityView.vue
@@ -4,14 +4,12 @@ import RollCallActivity from '@/components/activity/RollCallActivity.vue'
 import QuestionActivity from '@/components/activity/QuestionActivity.vue'
 import { apiClient } from '@/api/apiClient'
 import { qk } from '@/api/queries/keys'
-import type { components } from '@/api/schema'
 import { getDayStringNoPad } from '@/utils/date'
 import { computed } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
 import { useCampStore } from '@/store'
 import { useRoute } from 'vue-router'
-
-type Activity = components['schemas']['ActivityResponse']
+import type { Activity } from '@/typeAliases'
 
 const campStore = useCampStore()
 const route = useRoute()
@@ -81,58 +79,58 @@ const dailyActivities = computed(() => {
     <!-- Content -->
     <div v-else class="pa-4" :class="$style.container">
       <template v-for="day in dailyActivities" :key="day.date.toISOString()">
-      <h3 class="mb-2 mt-4" :class="$style.dayHeader">
-        {{ getDayStringNoPad(day.date) }}
-      </h3>
-      <div class="d-flex flex-column ga-3">
-        <template v-for="activity in day.activities" :key="`${activity.id}-${activity.time}`">
-          <activity-layout
-            v-if="activity.type === 'room_created'"
-            :type="activity.type"
-            :date="new Date(activity.time)"
-          >
-            <template #default="{ color }">
-              <span :class="`text-${color}`"> 部屋情報が公開されました </span>
-            </template>
-          </activity-layout>
-          <activity-layout
-            v-if="activity.type === 'payment_created'"
-            :type="activity.type"
-            :date="new Date(activity.time)"
-          >
-            <template #default="{ color }">
-              <span :class="`text-${color}`">
-                {{ activity.amount.toLocaleString() }} 円の支払いが作成されました
-              </span>
-            </template>
-          </activity-layout>
-          <activity-layout
-            v-if="activity.type === 'payment_amount_changed'"
-            :type="activity.type"
-            :date="new Date(activity.time)"
-          >
-            <template #default="{ color }">
-              <span :class="`text-${color}`">
-                支払い金額が {{ activity.amount.toLocaleString() }} 円に変更されました
-              </span>
-            </template>
-          </activity-layout>
-          <activity-layout
-            v-if="activity.type === 'payment_paid_changed'"
-            :type="activity.type"
-            :date="new Date(activity.time)"
-          >
-            <template #default="{ color }">
-              <span :class="`text-${color}`">
-                合宿係が {{ activity.amount.toLocaleString() }} 円の振込を確認しました
-              </span>
-            </template>
-          </activity-layout>
-          <roll-call-activity v-if="activity.type === 'roll_call_created'" :activity="activity" />
-          <question-activity v-if="activity.type === 'question_created'" :activity="activity" />
-        </template>
-      </div>
-    </template>
+        <h3 class="mb-2 mt-4" :class="$style.dayHeader">
+          {{ getDayStringNoPad(day.date) }}
+        </h3>
+        <div class="d-flex flex-column ga-3">
+          <template v-for="activity in day.activities" :key="`${activity.id}-${activity.time}`">
+            <activity-layout
+              v-if="activity.type === 'room_created'"
+              :type="activity.type"
+              :date="new Date(activity.time)"
+            >
+              <template #default="{ color }">
+                <span :class="`text-${color}`"> 部屋情報が公開されました </span>
+              </template>
+            </activity-layout>
+            <activity-layout
+              v-if="activity.type === 'payment_created'"
+              :type="activity.type"
+              :date="new Date(activity.time)"
+            >
+              <template #default="{ color }">
+                <span :class="`text-${color}`">
+                  {{ activity.amount.toLocaleString() }} 円の支払いが作成されました
+                </span>
+              </template>
+            </activity-layout>
+            <activity-layout
+              v-if="activity.type === 'payment_amount_changed'"
+              :type="activity.type"
+              :date="new Date(activity.time)"
+            >
+              <template #default="{ color }">
+                <span :class="`text-${color}`">
+                  支払い金額が {{ activity.amount.toLocaleString() }} 円に変更されました
+                </span>
+              </template>
+            </activity-layout>
+            <activity-layout
+              v-if="activity.type === 'payment_paid_changed'"
+              :type="activity.type"
+              :date="new Date(activity.time)"
+            >
+              <template #default="{ color }">
+                <span :class="`text-${color}`">
+                  合宿係が {{ activity.amount.toLocaleString() }} 円の振込を確認しました
+                </span>
+              </template>
+            </activity-layout>
+            <roll-call-activity v-if="activity.type === 'roll_call_created'" :activity="activity" />
+            <question-activity v-if="activity.type === 'question_created'" :activity="activity" />
+          </template>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/src/views/RegistrationView.vue
+++ b/src/views/RegistrationView.vue
@@ -5,12 +5,10 @@ import { computed } from 'vue'
 import { getDayStringNoPad } from '@/utils/date'
 import MarkdownPreview from '@/components/markdown/MarkdownPreview.vue'
 import { useRouter } from 'vue-router'
-import type { components } from '@/api/schema'
 import BackgroundPattern from '@/components/generic/BackgroundPattern.vue'
+import type { Camp } from '@/typeAliases'
 
 const version = __APP_VERSION__
-
-type Camp = components['schemas']['CampResponse']
 
 const router = useRouter()
 const campStore = useCampStore()

--- a/src/views/RollCallView.vue
+++ b/src/views/RollCallView.vue
@@ -3,12 +3,10 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCampStore, useUserStore } from '@/store'
 import { apiClient } from '@/api/apiClient'
-import type { components } from '@/api/schema'
 import BackgroundPattern from '@/components/generic/BackgroundPattern.vue'
 import UserResponse from '@/components/rollcall/UserResponse.vue'
 import { useRollCallStream } from '@/components/rollcall/rollCallStream'
-
-type RollCall = components['schemas']['RollCallResponse']
+import type { RollCall } from '@/typeAliases'
 
 const route = useRoute()
 const campStore = useCampStore()

--- a/src/views/RoomInfoView.vue
+++ b/src/views/RoomInfoView.vue
@@ -1,18 +1,16 @@
 <script setup lang="ts">
 import { apiClient } from '@/api/apiClient'
-import type { components } from '@/api/schema'
 import RoomCard from '@/components/room/RoomCard.vue'
 import { useCampStore } from '@/store'
 import { useRoute } from 'vue-router'
 import { useQuery } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
+import type { RoomGroup } from '@/typeAliases'
 
 const route = useRoute()
 const campStore = useCampStore()
 
 const displayCamp = campStore.getCampByDisplayId(route.params.campname as string)
-
-type RoomGroup = components['schemas']['RoomGroupResponse']
 
 const {
   data: roomGroups,

--- a/src/views/ScheduleView.vue
+++ b/src/views/ScheduleView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import ScheduleContent from '@/components/event/ScheduleContent.vue'
-import type { components } from '@/api/schema'
 import { computed } from 'vue'
 import { useCampStore } from '@/store'
 import { useRoute } from 'vue-router'
@@ -8,8 +7,7 @@ import { apiClient } from '@/api/apiClient'
 import EventEditor from '@/components/event/EventEditor.vue'
 import { useQuery } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
-
-type CampEvent = components['schemas']['EventResponse']
+import type { CampEvent } from '@/typeAliases'
 
 const campStore = useCampStore()
 const route = useRoute()

--- a/src/views/UserInfoView.vue
+++ b/src/views/UserInfoView.vue
@@ -6,15 +6,12 @@ import { apiClient } from '@/api/apiClient'
 import { computed } from 'vue'
 import { useCampStore } from '@/store'
 import { useRoute } from 'vue-router'
-import type { components } from '@/api/schema'
 import QuestionGroupPanel from '@/components/information/QuestionGroupPanel.vue'
 import RegisterCampButton from '@/components/information/RegisterCampButton.vue'
 import UnregisterCampButton from '@/components/information/UnregisterCampButton.vue'
 import { useQuery } from '@tanstack/vue-query'
 import { qk } from '@/api/queries/keys'
-
-type QuestionGroup = components['schemas']['QuestionGroupResponse'][]
-type Dashboard = components['schemas']['DashboardResponse']
+import type { QuestionGroup, Dashboard } from '@/typeAliases'
 
 const campStore = useCampStore()
 const route = useRoute()
@@ -24,7 +21,7 @@ const displayCamp = campStore.getCampByDisplayId(route.params.campname as string
 const isRegistered = computed(() => campStore.hasRegisteredLatest)
 
 // 質問グループ一覧
-const { data: questionGroups } = useQuery<QuestionGroup, Error>({
+const { data: questionGroups } = useQuery<QuestionGroup[], Error>({
   queryKey: qk.camps.questionGroups(displayCamp.id),
   queryFn: async () => {
     const { data, error } = await apiClient.GET('/api/camps/{campId}/question-groups', {


### PR DESCRIPTION
closes https://github.com/traPtitech/rucQ-UI/issues/172

古くなってコンフリクトが発生してどうにもならなくなっていた https://github.com/traPtitech/rucQ-UI/pull/214 をやり直したもの

これまでのコードでは各コンポーネントで

```ts
import type { components } from '@/api/schema'
type Camp = components['schemas']['CampResponse']
```

のようなボイラープレートによって型を使用していましたが、これを typeAliases.ts に集約します