### PR TITLE
アンケート結果の表示ダイアログを内側でスクロール可能にする

### DIFF
--- a/src/components/information/AnswersDialog.vue
+++ b/src/components/information/AnswersDialog.vue
@@ -117,22 +117,8 @@ const closeBtnProps = {
     </template>
 
     <template #default="{ isActive }">
-      <div v-if="xs" class="bg-white h-100">
-        <div :class="$style.heading">
-          <v-btn v-bind="closeBtnProps" @click="isActive.value = false" />
-        </div>
-        <v-expansion-panels v-model="openPanel" variant="accordion">
-          <answers-dialog-content
-            v-for="q in publicQuestions"
-            :key="q.id"
-            :question="q"
-            :answers="traQIDsByAnswer[q.id]"
-            :is-selected="openPanel === publicQuestions.indexOf(q)"
-          />
-        </v-expansion-panels>
-      </div>
-      <div v-else>
-        <v-card>
+      <v-card>
+        <div v-if="xs" class="bg-white h-100">
           <div :class="$style.heading">
             <v-btn v-bind="closeBtnProps" @click="isActive.value = false" />
           </div>
@@ -145,8 +131,24 @@ const closeBtnProps = {
               :is-selected="openPanel === publicQuestions.indexOf(q)"
             />
           </v-expansion-panels>
-        </v-card>
-      </div>
+        </div>
+        <div v-else>
+          <v-card>
+            <div :class="$style.heading">
+              <v-btn v-bind="closeBtnProps" @click="isActive.value = false" />
+            </div>
+            <v-expansion-panels v-model="openPanel" variant="accordion">
+              <answers-dialog-content
+                v-for="q in publicQuestions"
+                :key="q.id"
+                :question="q"
+                :answers="traQIDsByAnswer[q.id]"
+                :is-selected="openPanel === publicQuestions.indexOf(q)"
+              />
+            </v-expansion-panels>
+          </v-card>
+        </div>
+      </v-card>
     </template>
   </v-dialog>
 </template>

--- a/src/components/information/AnswersDialog.vue
+++ b/src/components/information/AnswersDialog.vue
@@ -133,20 +133,18 @@ const closeBtnProps = {
           </v-expansion-panels>
         </div>
         <div v-else>
-          <v-card>
-            <div :class="$style.heading">
-              <v-btn v-bind="closeBtnProps" @click="isActive.value = false" />
-            </div>
-            <v-expansion-panels v-model="openPanel" variant="accordion">
-              <answers-dialog-content
-                v-for="q in publicQuestions"
-                :key="q.id"
-                :question="q"
-                :answers="traQIDsByAnswer[q.id]"
-                :is-selected="openPanel === publicQuestions.indexOf(q)"
-              />
-            </v-expansion-panels>
-          </v-card>
+          <div :class="$style.heading">
+            <v-btn v-bind="closeBtnProps" @click="isActive.value = false" />
+          </div>
+          <v-expansion-panels v-model="openPanel" variant="accordion">
+            <answers-dialog-content
+              v-for="q in publicQuestions"
+              :key="q.id"
+              :question="q"
+              :answers="traQIDsByAnswer[q.id]"
+              :is-selected="openPanel === publicQuestions.indexOf(q)"
+            />
+          </v-expansion-panels>
         </div>
       </v-card>
     </template>


### PR DESCRIPTION
アンケート結果の表示ダイアログを内側でスクロール可能な状態にしました
close #79
<img width="1221" height="321" alt="スクリーンショット 2026-07-07 16 09 20" src="https://github.com/user-attachments/assets/8475d284-203b-4e55-b2fd-92df332bee5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 画面サイズに応じたダイアログのレイアウトを調整し、`xs` とそれ以外で表示構造がより一貫するようになりました。
  * モバイル表示時のカード配置を見直し、コンテンツが外側のカード内に適切に収まるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->