### PR TITLE
fix : v-ifを使って適切にNotFoundを表示するようにしました

### DIFF
--- a/src/layouts/CampLayout.vue
+++ b/src/layouts/CampLayout.vue
@@ -35,10 +35,7 @@ const campName = computed(() => displayCamp.value?.name)
 </script>
 
 <template>
-  <div v-if="!displayCamp">
-    <not-found-view />
-  </div>
-  <div v-else>
+  <template v-if="displayCamp">
     <background-pattern variant="light" />
     <header-button />
     <page-navigation />
@@ -49,7 +46,10 @@ const campName = computed(() => displayCamp.value?.name)
       </div>
       <router-view :style="{ marginTop: routerViewMargin }" />
     </v-main>
-  </div>
+  </template>
+  <template v-else>
+    <not-found-view />
+  </template>
 </template>
 
 <style module>

--- a/src/layouts/CampLayout.vue
+++ b/src/layouts/CampLayout.vue
@@ -6,6 +6,7 @@ import { useCampStore, useTimeStore } from '@/store'
 import { useRoute } from 'vue-router'
 import { computed } from 'vue'
 import { useDisplay } from 'vuetify'
+import NotFoundView from '@/views/NotFoundView.vue'
 
 const campStore = useCampStore()
 const timeStore = useTimeStore()
@@ -34,20 +35,21 @@ const campName = computed(() => displayCamp.value?.name)
 </script>
 
 <template>
-  <background-pattern variant="light" />
-  <header-button />
-  <page-navigation />
-  <v-main>
-    <div
-      v-if="isArchived && !xs"
-      :class="[$style.banner]"
-      class="bg-primaryLight"
-    >
-      <v-icon>mdi-archive</v-icon>
-      <span>{{ campName }} はアーカイブ済みです</span>
-    </div>
-    <router-view :style="{ marginTop: routerViewMargin }" />
-  </v-main>
+  <div v-if="!displayCamp">
+    <not-found-view />
+  </div>
+  <div v-else>
+    <background-pattern variant="light" />
+    <header-button />
+    <page-navigation />
+    <v-main>
+      <div v-if="isArchived && !xs" :class="[$style.banner]" class="bg-primaryLight">
+        <v-icon>mdi-archive</v-icon>
+        <span>{{ campName }} はアーカイブ済みです</span>
+      </div>
+      <router-view :style="{ marginTop: routerViewMargin }" />
+    </v-main>
+  </div>
 </template>
 
 <style module>
@@ -66,10 +68,4 @@ const campName = computed(() => displayCamp.value?.name)
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   z-index: 1;
 }
-
-
-
-
-
-
 </style>


### PR DESCRIPTION
displayCampをv-ifに使って、displayCampがnullのときにnotfoundviewを表示するようにしました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * キャンプが見つからない場合に、レイアウト本体の代わりに「見つかりません」表示を出すようになりました。
* **Bug Fixes**
  * キャンプ取得失敗時でも、適切な画面が表示されるようになりました。
  * キャンプがある場合は、これまでどおり背景、ヘッダー、ページナビ、アーカイブ表示、メイン内容を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->