### PR TITLE
feat:部屋ステータスログに編集者のIDを表示

### DIFF
--- a/src/components/room/RoomStatusDialog.vue
+++ b/src/components/room/RoomStatusDialog.vue
@@ -139,7 +139,7 @@ const updateStatus = async () => {
         <div class="pa-3 overflow-y-auto h-100 d-flex flex-column ga-2">
           <div v-for="log in statusHistory" :key="log.updatedAt">
             <div class="font-weight-bold text-caption text-grey">
-              {{ formatStatusTime(log.updatedAt) }}
+              {{ formatStatusTime(log.updatedAt) }} - {{ log.operatorId }}
             </div>
             <div :class="$style.status" class="d-flex">
               <div :class="[$style.statusMark, `bg-${getStatusColor(log.type)}`]"></div>


### PR DESCRIPTION
部屋ステータスログに編集者のIDを表示するようにしました

close: #233

<img width="722" height="305" alt="image" src="https://github.com/user-attachments/assets/8cf93817-a404-4571-b3db-5c190d1410e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 部屋ステータス履歴の表示で、更新日時に加えてオペレーターIDも確認できるようになりました。
  * ログの時刻表示が「日時 - オペレーターID」の形式になり、誰が更新したかを判別しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->