### PR TITLE
ログイン時リダイレクトにアラートを伴わせる

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,24 +32,6 @@ app.use(VueQueryPlugin, { queryClient })
 
 async function initializeApp() {
   if (window.location.pathname === '/login') {
-    if (import.meta.env.DEV) {
-      // 開発環境の場合、/login にリダイレクトしても traQ 認証が挟まるわけではない
-      // 無限ループしてしまうので、Cookie が適切に設定されているかどうかの確認を求め、
-      // ここでアプリケーションを終了する
-
-      alert(
-        [
-          '開発環境から Staging / Production API へのアクセスを試み、ログインに失敗しました。',
-          'Cookie が環境変数として正しく設定されていないか、古すぎる可能性があります。',
-        ].join(''),
-      )
-      return
-    }
-
-    // 本番環境の場合、サービスワーカーのキャッシュが更新されないことが問題であり、
-    // /login にアクセス出来たことは再度 rucQ サーバーに接続できたことを意味するので、
-    // トップページにリダイレクトする
-
     alert('ログインされました！ トップページにリダイレクトします')
     window.location.href = '/'
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ async function initializeApp() {
   if (window.location.pathname === '/login') {
     alert('ログインされました！ トップページにリダイレクトします')
     window.location.href = '/'
+    return
   }
 
   if (import.meta.env.DEV && import.meta.env.MODE === 'msw') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,24 @@ app.use(VueQueryPlugin, { queryClient })
 
 async function initializeApp() {
   if (window.location.pathname === '/login') {
+    if (import.meta.env.DEV) {
+      // 開発環境の場合、/login にリダイレクトしても traQ 認証が挟まるわけではない
+      // 無限ループしてしまうので、Cookie が適切に設定されているかどうかの確認を求め、
+      // ここでアプリケーションを終了する
+
+      alert(
+        [
+          '開発環境から Staging / Production API へのアクセスを試み、ログインに失敗しました。',
+          'Cookie が環境変数として正しく設定されていないか、古すぎる可能性があります。',
+        ].join(''),
+      )
+      return
+    }
+
+    // 本番環境の場合、サービスワーカーのキャッシュが更新されないことが問題であり、
+    // /login にアクセス出来たことは再度 rucQ サーバーに接続できたことを意味するので、
+    // トップページにリダイレクトする
+
     alert('ログインされました！ トップページにリダイレクトします')
     window.location.href = '/'
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,11 @@ app.use(vuetify)
 app.use(VueQueryPlugin, { queryClient })
 
 async function initializeApp() {
+  if (window.location.pathname === '/login') {
+    alert('ログインされました！ トップページにリダイレクトします')
+    window.location.href = '/'
+  }
+
   if (import.meta.env.DEV && import.meta.env.MODE === 'msw') {
     // 手動リロードによってキャッシュをクリア
     await localforage.clear()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,10 +6,6 @@ const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
-      path: '/login',
-      redirect: '/',
-    },
-    {
       path: '/',
       component: () => import('@/views/RegistrationView.vue'),
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,7 +32,9 @@ export const useUserStore = defineStore('user', () => {
                 'Cookie が環境変数として正しく設定されていないか、古すぎる可能性があります。',
               ].join(''),
             )
-            return
+            return new Promise<never>(() => {
+              // アプリの初期化を中断
+            })
           }
 
           window.location.href = '/login'

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,19 @@ export const useUserStore = defineStore('user', () => {
 
         // Temporary Redirect の場合、手動でリダイレクト処理を行う
         if (response.type === 'opaqueredirect') {
+          if (import.meta.env.DEV) {
+            // 開発環境の場合、/login にリダイレクトしても traQ 認証が挟まるわけではない
+            // 無限ループしてしまうので、Cookie が適切に設定されているかどうかの確認を求め、
+            // ここでアプリケーションを終了する
+            alert(
+              [
+                '開発環境から Staging / Production API へのアクセスを試み、ログインに失敗しました。',
+                'Cookie が環境変数として正しく設定されていないか、古すぎる可能性があります。',
+              ].join(''),
+            )
+            return
+          }
+
           window.location.href = '/login'
           return new Promise<never>(() => {
             // ユーザーにエラー表示をさせないよう、解決しない Promise を返す


### PR DESCRIPTION
開発環境では無限リロードが発生します

本来の `/login` リダイレクト処理はそれがサービスワーカーのキャッシュの穴を突いて traQ 認証に受け止められ、再度ログインすることを目的としたものです。開発環境でも `/` にアクセスしたとき `/api/me` にリクエストを投げ、ログアウト状態だったら `/login` にリダイレクトしますが、ここで traQ 認証が挟まれるわけではありません。従って無限リロードが発生します

このPRは以下の変更を含みます

- 開発環境では `/login` リダイレクトを行わない
- 本番環境でも万一の無限リロードを避けるために `/login` からのリダイレクト時にワンクッション alert を入れる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ログイン関連の遷移時に、状況に応じて注意メッセージを表示するようになりました。

* **バグ修正**
  * ログイン経路からのアクセス時の挙動を見直し、画面遷移の流れを整理しました。
  * 開発環境では、認証情報の不備が疑われる場合に不要な遷移を抑え、確認しやすくしました。
  * 一般環境では、従来どおりログインページへの遷移が維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->