### PR TITLE
fix: 部屋名表示の日本語フォントをフォールバック

### DIFF
--- a/src/components/information/RoomInfo.vue
+++ b/src/components/information/RoomInfo.vue
@@ -38,7 +38,7 @@ defineProps<{ room?: Room }>()
 }
 
 .room {
-  font-family: 'Reddit Sans Variable';
+  font-family: 'Reddit Sans Variable', 'M PLUS 2 Variable', sans-serif;
   font-size: 30px;
   font-weight: 800;
   letter-spacing: 3px;


### PR DESCRIPTION
fix #241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 一部の表示で、利用環境に応じて適切なフォントが順に使われるようになりました。表示の安定性が向上し、文字の見た目がより一貫します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->