### PR TITLE
アイコンのズレを修正

### DIFF
--- a/src/components/rollcall/UserResponse.vue
+++ b/src/components/rollcall/UserResponse.vue
@@ -34,7 +34,7 @@ const orderedUserIds = computed(() => {
         :key="id"
         id-tooltip
         :size="28"
-        :class="[id === userStore.user.id ? $style.myIcon : '', 'mr-2']"
+        :class="[id === userStore.user.id ? $style.myIcon : '', 'ml-1 mr-1']"
       />
       <v-dialog max-width="800">
         <template #activator="{ props: activatorProps }">


### PR DESCRIPTION
Close #243 
アイコン一覧の右側だけに余白が設定されてたため、右側だけの余白を左右に分けて表示するように変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 参加者アイコンの表示間隔を調整し、自分のアイコンまわりの余白をより自然にしました。
  * 表示順や表示件数はそのままに、見た目のみを改善しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->