### PR TITLE
Fix/msw navigation stability

### DIFF
--- a/src/components/layout/PageNavigation.vue
+++ b/src/components/layout/PageNavigation.vue
@@ -54,7 +54,7 @@ const navItems = [
 <template>
   <v-bottom-navigation
     v-if="xs"
-    v-model="currentPath"
+    :model-value="currentPath"
     color="primary"
     mandatory
     grow
@@ -77,7 +77,7 @@ const navItems = [
   <v-navigation-drawer v-else width="270" color="primary" permanent :class="$style.drawer" app>
     <background-pattern style="z-index: -1" variant="primary" />
     <img src="/logo/logo-white.svg" alt="rucQ Icon" :class="$style.logo" />
-    <v-list v-model:selected="selectedItems" dense mandatory>
+    <v-list :selected="selectedItems" dense mandatory>
       <v-list-item
         v-for="item in navItems"
         :key="item.path"

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -21,7 +21,8 @@ const [, restorePromise] = persistQueryClient({
   queryClient,
   persister: asyncPersister,
   maxAge: 7 * 24 * 60 * 60 * 1000, // 永続化キャッシュの寿命
-  buster: __APP_VERSION__, // package.json のバージョンを自動反映
+  // API の接続先ごとにキャッシュを分離する。
+  buster: `${__APP_VERSION__}:${import.meta.env.MODE}`,
   dehydrateOptions: {
     // データを持つクエリは永続化する
     shouldDehydrateQuery: (query) => query.state.data !== undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ import { vuetify } from '@/lib/vuetify'
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
 import { useUserStore, useCampStore } from './store'
-import localforage from 'localforage'
 
 import '@fontsource-variable/m-plus-2' // 'M PLUS 2 Variable'
 import '@fontsource-variable/m-plus-code-latin/wdth.css' // 'M PLUS Code Latin Variable' の幅広バリアント
@@ -38,11 +37,22 @@ async function initializeApp() {
   }
 
   if (import.meta.env.DEV && import.meta.env.MODE === 'msw') {
-    // 手動リロードによってキャッシュをクリア
-    await localforage.clear()
-    queryClient.clear()
-    const { worker } = await import('./mocks/browser')
-    await worker.start()
+    const controller = navigator.serviceWorker.controller
+
+    // 現在のページが PWA の Worker に制御されている場合は、登録を解除して制御を外す。
+    if (controller && new URL(controller.scriptURL).pathname !== '/mockServiceWorker.js') {
+      const registration = await navigator.serviceWorker.getRegistration()
+
+      if (registration) {
+        await registration.unregister()
+      }
+
+      window.location.reload()
+      return
+    }
+
+    const { startWorker } = await import('./mocks/browser')
+    await startWorker()
   }
 
   try {

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -2,3 +2,13 @@ import { setupWorker } from 'msw/browser'
 import { handlers } from './handlers/index'
 
 export const worker = setupWorker(...handlers)
+
+export const startWorker = () =>
+  worker.start({
+    // Vite の仮想モジュール（`/@id/...`）も Service Worker を通る。API の取りこぼしだけを
+    // 警告対象にして、初回の画面遷移で発生する開発用アセットや外部アセットの警告を抑える。
+    onUnhandledRequest(request, print) {
+      const url = new URL(request.url)
+      if (url.origin === window.location.origin && url.pathname.startsWith('/api/')) print.warning()
+    },
+  })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,9 @@ export default defineConfig(({ mode }) => {
         },
       }),
       VitePWA({
+        // MSW は同じ scope の Service Worker を登録する。MSW モードでは PWA 自体を
+        // 無効化して、開発用・ビルド時のどちらでも Worker を生成・登録させない。
+        disable: mode === 'msw',
         registerType: 'autoUpdate',
         manifest: {
           name: 'rucQ',


### PR DESCRIPTION
mswが不安定だったのを改善しました。
主にserviceworkerとの競合が原因みたいだったのでmswモードの際に登録解除と起動をしないようにしました
tanstackqueryとの競合もあるのでbusterに`import.meta.env.MODE`を追記しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ページ移動時の選択状態が正しく反映されるよう改善しました。
  * 実行モードごとにキャッシュを分離し、異なる環境のデータが混在しないようにしました。

* **開発者向け改善**
  * モック環境でのサービスワーカー起動やページ再読み込みを安定化しました。
  * モック環境ではPWA用サービスワーカーを無効化し、競合を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->