### PR TITLE
api/camps/campid/meでretryをしないように

### DIFF
--- a/src/views/UserInfoView.vue
+++ b/src/views/UserInfoView.vue
@@ -40,14 +40,14 @@ const {
   data: dashboard,
   isPending: isPendingDashboard,
   isFetching: isFetchingDashboard,
-} = useQuery<Dashboard, Error>({
+} = useQuery<Dashboard | null, Error>({
   queryKey: qk.camps.dashboard(displayCamp.id),
-  // 404 は未参加を表すため、既定のリトライを行わない。
-  retry: false,
   queryFn: async () => {
-    const { data, error } = await apiClient.GET('/api/camps/{campId}/me', {
+    const { data, error, response } = await apiClient.GET('/api/camps/{campId}/me', {
       params: { path: { campId: displayCamp.id } },
     })
+    // 404 は未参加を表すため、成功扱いで空のダッシュボードを返す。
+    if (response.status === 404) return null
     if (error) throw new Error(`ダッシュボード情報の取得に失敗しました: ${error.message}`)
     return data
   },

--- a/src/views/UserInfoView.vue
+++ b/src/views/UserInfoView.vue
@@ -42,6 +42,8 @@ const {
   isFetching: isFetchingDashboard,
 } = useQuery<Dashboard, Error>({
   queryKey: qk.camps.dashboard(displayCamp.id),
+  // 404 は未参加を表すため、既定のリトライを行わない。
+  retry: false,
   queryFn: async () => {
     const { data, error } = await apiClient.GET('/api/camps/{campId}/me', {
       params: { path: { campId: displayCamp.id } },


### PR DESCRIPTION
retryをfalseにしました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 未参加ユーザーのダッシュボード情報が見つからない場合、エラーではなく正常な未参加状態として扱うようにしました。
  * その他の取得エラーは引き続きエラーとして処理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->