### PR TITLE
Feat/renovate

### DIFF
--- a/.github/renovate-bot.json5
+++ b/.github/renovate-bot.json5
@@ -1,0 +1,4 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-global-schema.json',
+  repositories: ['traPtitech/rucQ-UI'],
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    "github>traPtitech/rucQ-UI//.github/renovate/npm.json5",
+    "github>traPtitech/rucQ-UI//.github/renovate/docker.json5",
+    "github>traPtitech/rucQ-UI//.github/renovate/github-actions.json5",
+    "github>traPtitech/rucQ-UI//.github/renovate/node.json5",
+    "github>traPtitech/rucQ-UI//.github/renovate/labels.json5"
+  ],
+  "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security"]
+  }
+}

--- a/.github/renovate/docker.json5
+++ b/.github/renovate/docker.json5
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group Docker non-major and digest updates",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "groupName": "Docker non-major dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+    },
+  ],
+}

--- a/.github/renovate/github-actions.json5
+++ b/.github/renovate/github-actions.json5
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions non-major and digest updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "groupName": "GitHub Actions non-major dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+    },
+  ],
+}

--- a/.github/renovate/github-actions.json5
+++ b/.github/renovate/github-actions.json5
@@ -1,6 +1,45 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    // 定期実行ワークフローで使用するRenovate本体（Dockerイメージのバージョンとダイジェスト）
+    {
+      "customType": "regex",
+      "description": "Update the Renovate image used by the GitHub Action",
+      "managerFilePatterns": [".github/workflows/renovate.yaml"],
+      "matchStrings": [
+        "renovate-version: (?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+      ],
+      "depNameTemplate": "ghcr.io/renovatebot/renovate",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+    },
+    // 設定検証ワークフローでnpx経由で使用するRenovate CLI（npmパッケージのバージョン）
+    {
+      "customType": "regex",
+      "description": "Update the Renovate config validator",
+      "managerFilePatterns": [
+        ".github/workflows/renovate-config-validator-ci.yaml",
+      ],
+      "matchStrings": ["renovate@(?<currentValue>[^\\s]+)"],
+      "depNameTemplate": "renovate",
+      "datasourceTemplate": "npm",
+    },
+  ],
   "packageRules": [
+    {
+      "description": "Keep the Renovate runner and validator in one update",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["ghcr.io/renovatebot/renovate", "renovate"],
+      "groupName": "Renovate",
+    },
+    {
+      "description": "Automerge non-major Renovate updates",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["ghcr.io/renovatebot/renovate", "renovate"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "automerge": true,
+      "automergeType": "pr",
+    },
     {
       "description": "Group GitHub Actions non-major and digest updates",
       "matchManagers": ["github-actions"],

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -15,7 +15,7 @@
       "addLabels": ["type/patch"],
     },
     {
-      "matchManagers": ["npm"],
+      "matchDatasources": ["npm"],
       "addLabels": ["renovate/npm"],
     },
     {

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["type/major"],
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["type/minor"],
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["type/patch"],
+    },
+    {
+      "matchManagers": ["npm"],
+      "addLabels": ["renovate/npm"],
+    },
+    {
+      "matchDatasources": ["docker"],
+      "addLabels": ["renovate/docker"],
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "addLabels": ["renovate/actions"],
+    },
+    {
+      "matchManagers": ["nodenv"],
+      "addLabels": ["renovate/node"],
+    },
+  ],
+}

--- a/.github/renovate/node.json5
+++ b/.github/renovate/node.json5
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["replacements:tsconfig-bases-node"],
+  "packageRules": [
+    {
+      "description": "Keep Node.js versions in one update",
+      "matchPackageNames": ["node", "@types/node", "@tsconfig/node**"],
+      "groupName": "Node.js",
+      "rangeStrategy": "bump",
+    },
+    {
+      "description": "Automerge non-major Node.js updates",
+      "matchPackageNames": ["node", "@types/node", "@tsconfig/node**"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "automerge": true,
+      "automergeType": "pr",
+    },
+  ],
+}

--- a/.github/renovate/npm.json5
+++ b/.github/renovate/npm.json5
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group npm minor and patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm minor and patch dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+    },
+  ],
+}

--- a/.github/workflows/renovate-config-validator-ci.yaml
+++ b/.github/workflows/renovate-config-validator-ci.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/renovate-bot.json5
       - .github/renovate.json
       - .github/renovate/**
       - .github/workflows/renovate-config-validator-ci.yaml
@@ -20,5 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Validate Renovate configuration
-        run: npx --yes --package renovate@43.261.4 -- renovate-config-validator --strict .github/renovate.json .github/renovate/*.json5
+      - name: Validate Renovate global configuration
+        run: npx --yes --package renovate@43.261.4 -- renovate-config-validator --strict .github/renovate-bot.json5
+
+      - name: Validate Renovate repository configuration
+        run: npx --yes --package renovate@43.261.4 -- renovate-config-validator --strict --no-global .github/renovate.json .github/renovate/*.json5

--- a/.github/workflows/renovate-config-validator-ci.yaml
+++ b/.github/workflows/renovate-config-validator-ci.yaml
@@ -1,0 +1,24 @@
+name: Renovate Config Validator
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/renovate.json
+      - .github/renovate/**
+      - .github/workflows/renovate-config-validator-ci.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  renovate-config-validator:
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate Renovate configuration
+        run: npx --yes --package renovate@43.261.4 -- renovate-config-validator --strict .github/renovate.json .github/renovate/*.json5

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,51 @@
+name: Renovate
+
+on:
+  push:
+    branches: ["main"]
+
+  schedule:
+    # Every day at 5 a.m. JST
+    - cron: "0 20 * * *"
+
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: Enable debug logging
+        type: boolean
+        default: false
+      dry_run:
+        description: Run in dry-run mode
+        type: boolean
+        default: true
+
+concurrency:
+  group: renovate
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: renovatebot/github-action@22e0a16091fc706b04affe6ae53d5e3358ac4023 # v46.1.19
+        with:
+          configurationFile: .github/renovate-bot.json5
+          token: ${{ steps.generate-token.outputs.token }}
+        env:
+          LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run && 'full' || '' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -45,6 +45,7 @@ jobs:
       - uses: renovatebot/github-action@22e0a16091fc706b04affe6ae53d5e3358ac4023 # v46.1.19
         with:
           configurationFile: .github/renovate-bot.json5
+          renovate-version: 43.261.4@sha256:adc66d8ffba5d835b9ef27768bd3176d07e7ea98c8dba274b07f511beea5fe81
           token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-
+          repositories: "rucQ-UI"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,18 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
+  "json.schemaDownload.trustedDomains": {
+    "https://docs.renovatebot.com/": true
+  },
+  "json5.schemas": [
+    {
+      "fileMatch": ["/.github/renovate-bot.json5"],
+      "url": "https://docs.renovatebot.com/renovate-global-schema.json"
+    },
+    {
+      "fileMatch": ["/.github/renovate/*.json5"],
+      "url": "https://docs.renovatebot.com/renovate-schema.json"
+    }
+  ],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Node.js のベースイメージを使用（LTS版）
-FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
+FROM node:22.22.0-alpine@sha256:e4bf2a82ad0a4037d28035ae71529873c069b13eb0455466ae0bc13363826e34 AS builder
 
 # 作業ディレクトリを設定
 WORKDIR /app
 
-# pnpm をインストール
-RUN npm install -g pnpm@11.5.0
+# package.json の packageManager で指定した pnpm を有効化
+RUN corepack enable
 
 # package.json と pnpm-lock.yaml をコピー
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 1. `mise settings add idiomatic_version_file_enable_tools node`を実行
 2. `mise install` を実行
 3. `node -v` を実行し、`.node-version` で指定したバージョンと一致することを確認
-3. `corepack enable && pnpm -v` を実行し、`package.json` の `packageManager` で指定したバージョンと一致することを確認
+4. `corepack enable && pnpm -v` を実行し、`package.json` の `packageManager` で指定したバージョンと一致することを確認
 
 ### fnmを使っている場合: 
 1. リポジトリルートをターミナルで開いて `fnm use --install-if-missing` を実行

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 ### miseを使っている場合:
 1. `mise settings add idiomatic_version_file_enable_tools node`を実行
 2. `mise install` を実行
-3. `node -v` を実行して `v22.22.0` と表示されることを確認
-3. `corepack enable && pnpm -v` を実行して `11.5.0` と表示されることを確認
+3. `node -v` を実行し、`.node-version` で指定したバージョンと一致することを確認
+3. `corepack enable && pnpm -v` を実行し、`package.json` の `packageManager` で指定したバージョンと一致することを確認
 
 ### fnmを使っている場合: 
 1. リポジトリルートをターミナルで開いて `fnm use --install-if-missing` を実行
-2. `node -v` を実行して `v22.22.0` と表示されることを確認
-3. `corepack enable && pnpm -v` を実行して `11.5.0` と表示されることを確認
+2. `node -v` を実行し、`.node-version` で指定したバージョンと一致することを確認
+3. `corepack enable && pnpm -v` を実行し、`package.json` の `packageManager` で指定したバージョンと一致することを確認
 
 ## 起動
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type-check": "vue-tsc --build",
     "lint": "eslint . --fix",
     "format": "prettier --write src/",
-    "generate:api": "npx openapi-typescript https://raw.githubusercontent.com/traPtitech/rucQ/main/openapi.yaml -o src/api/schema.d.ts && pnpm format"
+    "generate:api": "openapi-typescript https://raw.githubusercontent.com/traPtitech/rucQ/main/openapi.yaml -o src/api/schema.d.ts && pnpm format"
   },
   "packageManager": "pnpm@11.5.0",
   "engines": {


### PR DESCRIPTION
Renovateを導入し、npm・Node.js・Docker・GitHub Actionsの依存関係を自動更新できるようにしました。

## 変更内容

- GitHub ActionsでRenovateを毎日5時（JST）に実行
- GitHub Appのトークンを使用してRenovateを実行
- npm、Node.js、Docker、GitHub Actionsごとの更新ルールを追加
- minor・patch・digest更新のグループ化と自動マージを設定
- 更新内容に応じたラベルを付与
- 脆弱性アラートによる更新を有効化
- Renovate本体と設定validatorのバージョンをまとめて更新する設定を追加
- Renovate設定を検証するCIを追加
- DockerfileのNode.jsバージョンを`.node-version`と合わせ、pnpmをCorepack経由で使用するように変更
- READMEのNode.js・pnpmバージョン確認手順を更新



ciで確認してますが動作確認はマージしてみないとわからないです。

close #236 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 依存関係の更新を自動検出・提案する仕組みを導入しました。
  - 脆弱性や更新種別に応じたラベル付けに対応しました。
  - 安全性を確認した一部の更新を自動マージします。

- **品質改善**
  - 依存関係更新設定の自動検証を追加しました。
  - Node.jsおよびpnpmのビルド環境を更新しました。

- **ドキュメント**
  - Node.jsとpnpmのバージョン確認手順を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->