### PR TITLE
参加者の登録情報でfetchqueryを行っていてfreshの際に更新できていなかったので修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ async function initializeApp() {
     const userStore = useUserStore()
     const campStore = useCampStore()
     await userStore.initUser()
-    await campStore.initCamp(userStore.user)
+    await campStore.initCamp()
   } catch (error) {
     console.error(error)
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -69,8 +69,10 @@ export const useCampStore = defineStore('camp', () => {
   const latestCamp = ref<Camp>()
   const allCamps = ref<Camp[]>([])
   const hasRegisteredLatest = ref(false) // 最新の合宿に参加登録済みかどうか
+  let currentUser: User
 
   const initCamp = async (me: User) => {
+    currentUser = me
     const camps = await queryClient.ensureQueryData<Camp[]>({
       queryKey: qk.camps.lists(),
       queryFn: async () => {
@@ -118,18 +120,15 @@ export const useCampStore = defineStore('camp', () => {
     })
     if (error) throw new Error(`合宿参加登録に失敗しました: ${error.message}`)
     hasRegisteredLatest.value = true
-    // 参加登録後は参加者リストを即時更新
-    const participantsKey = qk.camps.participants(campId)
 
-    await queryClient.fetchQuery({
-      queryKey: participantsKey,
-      queryFn: async () => {
-        const { data, error } = await apiClient.GET('/api/camps/{campId}/participants', {
-          params: { path: { campId } },
-        })
-        if (error) throw new Error(`合宿参加者情報の取得に失敗しました: ${error.message}`)
-        return data
-      },
+    // 参加登録後は参加者リストのキャッシュに自分を追加
+    const participantsKey = qk.camps.participants(campId)
+    queryClient.setQueryData<User[]>(participantsKey, (participants) => {
+      if (!participants) return participants
+      if (participants.some((participant) => participant.id === currentUser.id)) {
+        return participants
+      }
+      return [...participants, currentUser]
     })
   }
 
@@ -139,19 +138,12 @@ export const useCampStore = defineStore('camp', () => {
     })
     if (error) throw new Error(`合宿参加取り消しに失敗しました: ${error.message}`)
     hasRegisteredLatest.value = false
-    // 参加取り消し後は参加者リストを即時更新
-    const participantsKey = qk.camps.participants(campId)
 
-    await queryClient.fetchQuery({
-      queryKey: participantsKey,
-      queryFn: async () => {
-        const { data, error } = await apiClient.GET('/api/camps/{campId}/participants', {
-          params: { path: { campId } },
-        })
-        if (error) throw new Error(`合宿参加者情報の取得に失敗しました: ${error.message}`)
-        return data
-      },
-    })
+    // 参加取り消し後は参加者リストのキャッシュから自分を除外
+    const participantsKey = qk.camps.participants(campId)
+    queryClient.setQueryData<User[]>(participantsKey, (participants) =>
+      participants?.filter((participant) => participant.id !== currentUser.id),
+    )
   }
 
   // 指定した合宿がユーザーにとって操作可能かどうかを判定

--- a/src/store.ts
+++ b/src/store.ts
@@ -66,13 +66,12 @@ export const useUserStore = defineStore('user', () => {
 
 export const useCampStore = defineStore('camp', () => {
   const queryClient = useQueryClient()
+  const userStore = useUserStore()
   const latestCamp = ref<Camp>()
   const allCamps = ref<Camp[]>([])
   const hasRegisteredLatest = ref(false) // 最新の合宿に参加登録済みかどうか
-  let currentUser: User
 
-  const initCamp = async (me: User) => {
-    currentUser = me
+  const initCamp = async () => {
     const camps = await queryClient.ensureQueryData<Camp[]>({
       queryKey: qk.camps.lists(),
       queryFn: async () => {
@@ -102,7 +101,7 @@ export const useCampStore = defineStore('camp', () => {
         },
       },
     )
-    hasRegisteredLatest.value = participants.some((user) => user.id === me.id)
+    hasRegisteredLatest.value = participants.some((user) => user.id === userStore.user.id)
   }
 
   // パスパラメータから合宿を取得する関数
@@ -125,10 +124,10 @@ export const useCampStore = defineStore('camp', () => {
     const participantsKey = qk.camps.participants(campId)
     queryClient.setQueryData<User[]>(participantsKey, (participants) => {
       if (!participants) return participants
-      if (participants.some((participant) => participant.id === currentUser.id)) {
+      if (participants.some((participant) => participant.id === userStore.user.id)) {
         return participants
       }
-      return [...participants, currentUser]
+      return [...participants, userStore.user]
     })
   }
 
@@ -142,7 +141,7 @@ export const useCampStore = defineStore('camp', () => {
     // 参加取り消し後は参加者リストのキャッシュから自分を除外
     const participantsKey = qk.camps.participants(campId)
     queryClient.setQueryData<User[]>(participantsKey, (participants) =>
-      participants?.filter((participant) => participant.id !== currentUser.id),
+      participants?.filter((participant) => participant.id !== userStore.user.id),
     )
   }
 


### PR DESCRIPTION
fetchqueryがfreshな状態の時に情報を更新しなかったのでsetquerydataで書き換えるようにしました



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 参加登録・参加取り消し後に、参加者一覧がより即時に反映されるようになりました。
  * 参加登録時は、自分が参加者に含まれていない場合のみ自分を追加して更新します。
  * 参加取り消し時は、自分を参加者一覧から除外して更新します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->